### PR TITLE
Add PT-BR Translation

### DIFF
--- a/App/MainWindow.ui
+++ b/App/MainWindow.ui
@@ -116,13 +116,6 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>TextLabel</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Password:</string>

--- a/App/Resource/Translations/RabbitCommonApp_ar.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ar.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ca.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ca.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_cs.ts
+++ b/App/Resource/Translations/RabbitCommonApp_cs.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_da.ts
+++ b/App/Resource/Translations/RabbitCommonApp_da.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_de.ts
+++ b/App/Resource/Translations/RabbitCommonApp_de.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_el.ts
+++ b/App/Resource/Translations/RabbitCommonApp_el.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_en.ts
+++ b/App/Resource/Translations/RabbitCommonApp_en.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_en_GB.ts
+++ b/App/Resource/Translations/RabbitCommonApp_en_GB.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_es.ts
+++ b/App/Resource/Translations/RabbitCommonApp_es.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_et.ts
+++ b/App/Resource/Translations/RabbitCommonApp_et.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_fi.ts
+++ b/App/Resource/Translations/RabbitCommonApp_fi.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_fr.ts
+++ b/App/Resource/Translations/RabbitCommonApp_fr.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_gd.ts
+++ b/App/Resource/Translations/RabbitCommonApp_gd.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_gl.ts
+++ b/App/Resource/Translations/RabbitCommonApp_gl.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_hu.ts
+++ b/App/Resource/Translations/RabbitCommonApp_hu.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_it.ts
+++ b/App/Resource/Translations/RabbitCommonApp_it.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ja.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ja.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ko.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ko.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_nb.ts
+++ b/App/Resource/Translations/RabbitCommonApp_nb.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ne.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ne.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_nl.ts
+++ b/App/Resource/Translations/RabbitCommonApp_nl.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_nn.ts
+++ b/App/Resource/Translations/RabbitCommonApp_nn.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_oc.ts
+++ b/App/Resource/Translations/RabbitCommonApp_oc.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_pl.ts
+++ b/App/Resource/Translations/RabbitCommonApp_pl.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_pt_BR.ts
+++ b/App/Resource/Translations/RabbitCommonApp_pt_BR.ts
@@ -6,88 +6,113 @@
     <message>
         <location filename="../../MainWindow.ui" line="14"/>
         <source>MainWindow</source>
-        <translation type="unfinished"></translation>
+        <translation>Janela Principal</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="37"/>
+        <source>Log</source>
+        <translation>Log</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="23"/>
-        <source>Log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
         <source>Generate core file</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerar arquivo de despejo de memória</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
-        <translation type="unfinished"></translation>
+        <translation>Thread de despejo de memória</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation>Comando:</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation>Parâmetros:</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation>Executar programa como administrador</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation>Arquivo de atualização:</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation>Procurar</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation>Executar atualização</translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Senha:</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
-        <translation type="unfinished"></translation>
+        <translation>Criptografar</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixar arquivo</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
-        <translation type="unfinished"></translation>
+        <translation>Adicionar arquivo</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixar</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajuda</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Ferramentas</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Sobre</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Atualizar</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de pasta</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
-        <translation type="unfinished"></translation>
+        <translation>Criptografado:</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
-        <translation type="unfinished"></translation>
+        <translation>Origem:</translation>
     </message>
 </context>
 <context>
@@ -95,7 +120,7 @@
     <message>
         <location filename="../../main.cpp" line="46"/>
         <source>RabbitCommon</source>
-        <translation type="unfinished"></translation>
+        <translation>RabbitCommon</translation>
     </message>
 </context>
 </TS>

--- a/App/Resource/Translations/RabbitCommonApp_pt_PT.ts
+++ b/App/Resource/Translations/RabbitCommonApp_pt_PT.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ro.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ro.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_ru.ts
+++ b/App/Resource/Translations/RabbitCommonApp_ru.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_sk.ts
+++ b/App/Resource/Translations/RabbitCommonApp_sk.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_sl.ts
+++ b/App/Resource/Translations/RabbitCommonApp_sl.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_sv.ts
+++ b/App/Resource/Translations/RabbitCommonApp_sv.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_th.ts
+++ b/App/Resource/Translations/RabbitCommonApp_th.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_tr.ts
+++ b/App/Resource/Translations/RabbitCommonApp_tr.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_uk.ts
+++ b/App/Resource/Translations/RabbitCommonApp_uk.ts
@@ -9,83 +9,108 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_zh_CN.ts
+++ b/App/Resource/Translations/RabbitCommonApp_zh_CN.ts
@@ -9,83 +9,108 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation>用超级用户权限执行程序</translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation>密码：</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation>加密</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation>产生崩溃文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation>日志</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation>线程崩溃</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation>下载文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation>增加文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation>工具</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation>文件夹浏览器</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation>加密：</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation>源：</translation>
     </message>

--- a/App/Resource/Translations/RabbitCommonApp_zh_TW.ts
+++ b/App/Resource/Translations/RabbitCommonApp_zh_TW.ts
@@ -9,83 +9,108 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="42"/>
-        <source>Exec program use root</source>
-        <translation>用超級用戶權限執行程序</translation>
-    </message>
-    <message>
-        <location filename="../../MainWindow.ui" line="69"/>
+        <location filename="../../MainWindow.ui" line="121"/>
         <source>Password:</source>
         <translation>密碼：</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="93"/>
+        <location filename="../../MainWindow.ui" line="145"/>
         <source>Encrypt</source>
         <translation>加密</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="49"/>
+        <location filename="../../MainWindow.ui" line="23"/>
         <source>Generate core file</source>
         <translation>產生崩潰文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="23"/>
+        <location filename="../../MainWindow.ui" line="37"/>
         <source>Log</source>
         <translation>日誌</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="56"/>
+        <location filename="../../MainWindow.ui" line="30"/>
         <source>Thread core</source>
         <translation>線程崩潰</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="104"/>
+        <location filename="../../MainWindow.ui" line="60"/>
+        <source>Command:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="70"/>
+        <source>Parameters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="80"/>
+        <source>Exec program with root</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="91"/>
+        <source>Update file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="101"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="108"/>
+        <source>Execute update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../MainWindow.ui" line="156"/>
         <source>Download file</source>
         <translation>下載文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="119"/>
+        <location filename="../../MainWindow.ui" line="171"/>
         <source>Add file</source>
         <translation>增加文件</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="126"/>
+        <location filename="../../MainWindow.ui" line="178"/>
         <source>Download</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="148"/>
+        <location filename="../../MainWindow.ui" line="200"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="155"/>
+        <location filename="../../MainWindow.ui" line="207"/>
         <source>Tools</source>
         <translation>工具</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="168"/>
+        <location filename="../../MainWindow.ui" line="220"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="176"/>
+        <location filename="../../MainWindow.ui" line="228"/>
         <source>Update</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.ui" line="181"/>
+        <location filename="../../MainWindow.ui" line="233"/>
         <location filename="../../MainWindow.cpp" line="78"/>
         <source>Folder browser</source>
         <translation>文件夾瀏覽器</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Encrypt:</source>
         <translation>加密：</translation>
     </message>
     <message>
-        <location filename="../../MainWindow.cpp" line="151"/>
+        <location filename="../../MainWindow.cpp" line="156"/>
         <source>Source:</source>
         <translation>源：</translation>
     </message>

--- a/FileBrowser/Resource/Translations/FileBrowser_pt_BR.ts
+++ b/FileBrowser/Resource/Translations/FileBrowser_pt_BR.ts
@@ -6,22 +6,22 @@
     <message>
         <location filename="../../MainWindow.ui" line="14"/>
         <source>File browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de arquivos</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="28"/>
         <source>Tools(&amp;T)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ferramentas(&amp;F)</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="34"/>
         <source>Help(&amp;H)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajuda(&amp;A)</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="48"/>
         <source>Status(&amp;S)</source>
-        <translation type="unfinished"></translation>
+        <translation>Status(&amp;S)</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="51"/>
@@ -29,12 +29,12 @@
         <location filename="../../MainWindow.ui" line="57"/>
         <location filename="../../MainWindow.ui" line="60"/>
         <source>Status</source>
-        <translation type="unfinished"></translation>
+        <translation>Status</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="68"/>
         <source>About(&amp;A)</source>
-        <translation type="unfinished"></translation>
+        <translation>Sobre(&amp;S)</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="71"/>
@@ -42,19 +42,19 @@
         <location filename="../../MainWindow.ui" line="77"/>
         <location filename="../../MainWindow.ui" line="80"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Sobre</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="88"/>
         <source>Update(&amp;U)</source>
-        <translation type="unfinished"></translation>
+        <translation>Atualizar(&amp;A)</translation>
     </message>
     <message>
         <location filename="../../MainWindow.ui" line="91"/>
         <location filename="../../MainWindow.ui" line="94"/>
         <location filename="../../MainWindow.ui" line="97"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation>Atualizar</translation>
     </message>
 </context>
 <context>
@@ -62,7 +62,7 @@
     <message>
         <location filename="../../main.cpp" line="20"/>
         <source>File browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de arquivos</translation>
     </message>
 </context>
 </TS>

--- a/MimeTypeBrowser/Resource/Translations/MimeTypeBrowser_pt_BR.ts
+++ b/MimeTypeBrowser/Resource/Translations/MimeTypeBrowser_pt_BR.ts
@@ -6,89 +6,89 @@
     <message>
         <location filename="../../mainwindow.cpp" line="27"/>
         <source>Qt Mime Database Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de banco de dados MIME do Qt</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="29"/>
         <source>&amp;File</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Arquivo</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="31"/>
         <source>&amp;Detect File Type...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Detectar Tipo de Arquivo...</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="34"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sair</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="37"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="39"/>
         <source>&amp;Find...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Localizar...</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="41"/>
         <source>Find &amp;Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Localizar &amp;Próxima</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="43"/>
         <source>Find &amp;Previous</source>
-        <translation type="unfinished"></translation>
+        <translation>Localizar &amp;Anterior</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="47"/>
         <source>&amp;About</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sobre</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="47"/>
         <source>&amp;About Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Sobre o Qt</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="83"/>
         <source>Choose File</source>
-        <translation type="unfinished"></translation>
+        <translation>Procurar</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="92"/>
         <source>&quot;%1&quot; is of type &quot;%2&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; é do tipo &quot;%2&quot;</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="96"/>
         <source>Unknown File Type</source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo de Arquivo Desconhecido</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="97"/>
         <source>The type of %1 could not be determined.</source>
-        <translation type="unfinished"></translation>
+        <translation>O tipo de %1 não pôde ser determinado.</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="128"/>
         <source>Find</source>
-        <translation type="unfinished"></translation>
+        <translation>Localizar</translation>
     </message>
     <message>
         <location filename="../../mainwindow.cpp" line="129"/>
         <source>Text:</source>
-        <translation type="unfinished"></translation>
+        <translation>Texto:</translation>
     </message>
     <message numerus="yes">
         <location filename="../../mainwindow.cpp" line="142"/>
         <source>%n mime types match &quot;%1&quot;.</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n tipo MIME corresponde a &quot;%1&quot;.</numerusform>
+            <numerusform>%n tipos MIME correspondem a &quot;%1&quot;.</numerusform>
         </translation>
     </message>
 </context>
@@ -97,7 +97,7 @@
     <message>
         <location filename="../../mimetypemodel.cpp" line="42"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome</translation>
     </message>
 </context>
 <context>
@@ -105,7 +105,7 @@
     <message>
         <location filename="../../main.cpp" line="13"/>
         <source>Mime type browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de tipos MIME</translation>
     </message>
 </context>
 </TS>

--- a/Src/CoreDump/MiniDumper.cpp
+++ b/Src/CoreDump/MiniDumper.cpp
@@ -329,7 +329,7 @@ LONG CMiniDumper::writeMiniDump( _EXCEPTION_POINTERS *pExceptionInfo )
         else
         {
             TCHAR msg[1024];
-            wsprintf(msg, _T("I'm Sorry, Application is Crash! The path: %s"), m_szMiniDumpPath);
+            wsprintf(msg, _T("I'm Sorry, Application has Crashed! The path: %s"), m_szMiniDumpPath);
             ::MessageBox(NULL, msg, _T("Application Error"), MB_OK);
         }
     }

--- a/Src/CoreDump/QMiniDumper.cpp
+++ b/Src/CoreDump/QMiniDumper.cpp
@@ -199,7 +199,7 @@ LONG WINAPI AppExceptionCallback(struct _EXCEPTION_POINTERS *pException)
     // 提示
     QString szTitle = QObject::tr("Application Error");
     QString szContent
-        = QObject::tr("I'm Sorry, Application is Crash!") + "\n\n"
+        = QObject::tr("I'm Sorry, Application has Crashed!") + "\n\n"
           + QObject::tr("Current path: ") + QDir::currentPath() + "\n\n";
     if(bDumpFile)
           szContent += QObject::tr("Dump file: ") + dumpName + "\n\n";

--- a/Src/DlgAbout/DlgAbout.ui
+++ b/Src/DlgAbout/DlgAbout.ui
@@ -189,7 +189,10 @@
      <item>
       <widget class="QPushButton" name="pbOK">
        <property name="text">
-        <string>OK</string>
+        <string>OK(&amp;O)</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -262,7 +265,7 @@
            <item>
             <widget class="QPushButton" name="pbDetails">
              <property name="text">
-              <string>Details</string>
+              <string>Details(&amp;D)</string>
              </property>
             </widget>
            </item>

--- a/Src/DlgAbout/Information.cpp
+++ b/Src/DlgAbout/Information.cpp
@@ -82,7 +82,7 @@ CInformation::CInformation(const QString &szApp,
         szQt += "  - " + tr("Build Version: ")
                 + QSslSocket::sslLibraryBuildVersionString() + "\n";
 #endif
-        szQt += "  - " + tr("Don't install OPENSSL dynamic library. Please install it") + "\n";
+        szQt += "  - " + tr("Doesn't have OPENSSL dynamic library installed. Please install it") + "\n";
     }
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
     szQt += "### " + tr("Standard paths:") + "\n";
@@ -128,8 +128,8 @@ CInformation::CInformation(const QString &szApp,
 #if QT_VERSION > QT_VERSION_CHECK(5, 4, 0)
     szOS = "### " + tr("OS") + "\n";
     szOS += "- " + tr("OS: ") + QSysInfo::prettyProductName() + "\n";
-    szOS += "  - " + tr("product type: ") + QSysInfo::productType() + "\n";
-    szOS += "  - " + tr("product version: ") + QSysInfo::productVersion() + "\n";
+    szOS += "  - " + tr("Product type: ") + QSysInfo::productType() + "\n";
+    szOS += "  - " + tr("Product version: ") + QSysInfo::productVersion() + "\n";
     szOS += "- " + tr("Kernel type: ") + QSysInfo::kernelType() + "\n";
     szOS += "- " + tr("Kernel version: ") + QSysInfo::kernelVersion() + "\n";
 #if QT_VERSION > QT_VERSION_CHECK(5, 11, 0)
@@ -152,7 +152,7 @@ CInformation::CInformation(const QString &szApp,
 #endif
 
     QString szEnv;
-    szEnv += "### " + tr("Environment:") + "\n";
+    szEnv += "### " + tr("Environment Variables:") + "\n";
     auto env = QProcessEnvironment::systemEnvironment();
     foreach (auto key, env.keys()) {
         szEnv += "  - " + key + "=" + env.value(key) + "\n";

--- a/Src/Download.cpp
+++ b/Src/Download.cpp
@@ -225,13 +225,13 @@ void CDownload::slotReadyRead()
     QNetworkReply* pReply = dynamic_cast<QNetworkReply*>(this->sender());
     if(m_Reply.find(pReply) == m_Reply.end())
     {
-        qCritical(log) << "The reply isn't exits";
+        qCritical(log) << "The reply doesn't exits";
         return;
     }
     QSharedPointer<QFile> file = m_DownloadFile[m_Reply[pReply]];
     if(!file)
     {
-        qCritical(log) << "The file isn't exits.";
+        qCritical(log) << "The file doesn't exits.";
         return;
     }
     if(file && file->isOpen())
@@ -247,7 +247,7 @@ void CDownload::slotFinished()
     QNetworkReply* pReply = dynamic_cast<QNetworkReply*>(this->sender());
     if(m_Reply.find(pReply) == m_Reply.end())
     {
-        qCritical(log) << "The reply isn't exits" << pReply->url();
+        qCritical(log) << "The reply doesn't exits" << pReply->url();
         return;
     }
     int nIndex = m_Reply[pReply];
@@ -286,7 +286,7 @@ void CDownload::slotFinished()
     QSharedPointer<QFile> file = m_DownloadFile[nIndex];
     if(!file)
     {
-        qCritical(log) << "The file isn't exits. index:" << nIndex;
+        qCritical(log) << "The file doesn't exits. index:" << nIndex;
         return;
     }   
     file->close();
@@ -298,7 +298,7 @@ void CDownload::slotError(QNetworkReply::NetworkError e)
     QNetworkReply* pReply = dynamic_cast<QNetworkReply*>(this->sender());
     if(m_Reply.find(pReply) == m_Reply.end())
     {
-        qCritical(log) << "Network error: The reply isn't exits."
+        qCritical(log) << "Network error: The reply doesn't exits."
                          << pReply->url() << "NetworkError:" << e;
         return;
     }
@@ -343,7 +343,7 @@ void CDownload::slotSslError(const QList<QSslError> e)
     QNetworkReply* pReply = dynamic_cast<QNetworkReply*>(this->sender());
     if(m_Reply.find(pReply) == m_Reply.end())
     {
-        qCritical(log) << "ssl error: The reply isn't exits. QSslError:" << e;
+        qCritical(log) << "ssl error: The reply doesn't exits. QSslError:" << e;
         return;
     }
     int nIndex = m_Reply[pReply];
@@ -354,7 +354,7 @@ void CDownload::slotSslError(const QList<QSslError> e)
     QSharedPointer<QFile> file = m_DownloadFile[nIndex];
     if(!file)
     {
-        qCritical(log) << "ssl error: The file null. index: "
+        qCritical(log) << "ssl error: The file is null. index: "
                         + QString::number(nIndex);
         return;
     }
@@ -390,12 +390,12 @@ void CDownload::slotDownloadProgress(qint64 bytesReceived, qint64 bytesTotal)
     QNetworkReply* pReply = dynamic_cast<QNetworkReply*>(this->sender());
     if(!pReply)
     {
-        qCritical(log) << "slotDownloadProgress: The sender is not reply";
+        qCritical(log) << "slotDownloadProgress: The sender doesn't reply";
         return;
     }
     if(m_Reply.find(pReply) == m_Reply.end())
     {
-        qCritical(log) << "slotDownloadProgress: The reply isn't exits"
+        qCritical(log) << "slotDownloadProgress: The reply doesn't exits"
                        << pReply->url();
         return;
     }
@@ -403,7 +403,7 @@ void CDownload::slotDownloadProgress(qint64 bytesReceived, qint64 bytesTotal)
     QSharedPointer<QFile> file = m_DownloadFile[nIndex];
     if(!file)
     {
-        qCritical(log) << "slotDownloadProgress: The file null. index: "
+        qCritical(log) << "slotDownloadProgress: The file is null. index: "
                               + QString::number(nIndex);
         return;
     }

--- a/Src/Download.cpp
+++ b/Src/Download.cpp
@@ -165,7 +165,7 @@ int CDownload::DownloadFile(int nIndex, const QUrl &url, bool bRedirection)
             return 0;
         }
 
-        QString szErr = tr("The file is not exists: ") + file->fileName();
+        QString szErr = tr("The file doesn't exists: ") + file->fileName();
         qCritical(log) << szErr;
         emit sigError(-6, szErr);
         return -6;

--- a/Src/FileBrowser/FileBrowser.cpp
+++ b/Src/FileBrowser/FileBrowser.cpp
@@ -177,7 +177,7 @@ CFileBrowser::CFileBrowser(QWidget *parent)
             }
         });
 
-        szTitle = tr("Option");
+        szTitle = tr("Options");
         QToolButton* pButtonOption = new QToolButton(pToolBar);
         pButtonOption->setIcon(QIcon::fromTheme("emblem-system"));
         pButtonOption->setStatusTip(szTitle);
@@ -186,7 +186,7 @@ CFileBrowser::CFileBrowser(QWidget *parent)
         pButtonOption->setMenu(pMenuOption);
         pToolBar->addWidget(pButtonOption);
 
-        szTitle = tr("Hidden file");
+        szTitle = tr("Hidden files");
         m_pHiddenFile = pMenuOption->addAction(
             szTitle, this,
             [&]() {

--- a/Src/FrmUpdater/FrmUpdater.cpp
+++ b/Src/FrmUpdater/FrmUpdater.cpp
@@ -65,7 +65,7 @@ CFrmUpdater::CFrmUpdater(QWidget *parent) :
 
     int id = set.value("Update/RadioButton", -2).toInt();
     m_ButtonGroup.addButton(ui->rbEveryTime);
-    m_ButtonGroup.addButton(ui->rbEveryDate);
+    m_ButtonGroup.addButton(ui->rbEveryDay);
     m_ButtonGroup.addButton(ui->rbEveryWeek);
     m_ButtonGroup.addButton(ui->rbEveryMonth);
     m_ButtonGroup.button(id)->setChecked(true);
@@ -79,7 +79,7 @@ CFrmUpdater::CFrmUpdater(QWidget *parent) :
     Q_ASSERT(check);
     SetTitle();
 
-    ui->lbCurrentArch->setText(tr("Current archecture: %1")
+    ui->lbCurrentArch->setText(tr("Current architecture: %1")
                  .arg(QSysInfo::currentCpuArchitecture()));
 
     QString szVerion = qApp->applicationVersion();
@@ -105,7 +105,7 @@ CFrmUpdater::CFrmUpdater(QWidget *parent) :
         szMsg = "BuildVersion: " + QSslSocket::sslLibraryBuildVersionString();
 #endif
         qCritical(log) <<
-              "QSslSocket is not support ssl. The system is not install the OPENSSL dynamic library[" << szMsg << "]."
+              "QSslSocket doesn't support SSL. The system doesn't have the OPENSSL dynamic library installed [" << szMsg << "]."
               " Please install OPENSSL dynamic library [" << szMsg << "]";
     }
 }
@@ -218,7 +218,7 @@ int CFrmUpdater::InitStateMachine()
     s->addTransition(this, SIGNAL(sigFinished()), sFinal);
 
     s->setInitialState(sDownloadConfigFile);
-    sDownloadConfigFile->assignProperty(ui->lbState, "text", tr("Being Download config file"));
+    sDownloadConfigFile->assignProperty(ui->lbState, "text", tr("Downloading config file"));
     sDownloadConfigFile->addTransition(this, SIGNAL(sigFinished()), sCheckConfigFile);
     check = connect(sDownloadConfigFile, SIGNAL(entered()),
                      this, SLOT(slotDownloadFile()));
@@ -233,11 +233,11 @@ int CFrmUpdater::InitStateMachine()
 
     m_pStateDownloadSetupFile = sDownloadSetupFile;
     sDownloadSetupFile->addTransition(this, SIGNAL(sigFinished()), sUpdate);
-    sDownloadSetupFile->assignProperty(ui->lbState, "text", tr("Being download update file"));
+    sDownloadSetupFile->assignProperty(ui->lbState, "text", tr("Downloading update file"));
     check = connect(sDownloadSetupFile, SIGNAL(entered()), this, SLOT(slotDownloadSetupFile()));
     Q_ASSERT(check);
 
-    sUpdate->assignProperty(ui->lbState, "text", tr("Being install update"));
+    sUpdate->assignProperty(ui->lbState, "text", tr("Installing update"));
     check = connect(sUpdate, SIGNAL(entered()), this, SLOT(slotUpdate()));
     Q_ASSERT(check);
 
@@ -294,7 +294,7 @@ void CFrmUpdater::slotCheck()
     }
 
     int n = 0;
-    if(ui->rbEveryDate->isChecked())
+    if(ui->rbEveryDay->isChecked())
         n = 1;
     else if(ui->rbEveryWeek->isChecked())
         n = 7;
@@ -313,7 +313,7 @@ void CFrmUpdater::slotDownloadError(int nErr, const QString szError)
     ui->progressBar->hide();
     ui->progressBar->setRange(0, 100);;
     QString szMsg;
-    szMsg = tr("Failed:") + tr("Download file is Failed.");
+    szMsg = tr("Failed:") + " " + tr("Downloading file has Failed.");
     if(!szError.isEmpty())
         szMsg += "(" + szError + ")";
     ui->lbState->setText(szMsg);
@@ -452,7 +452,7 @@ int CFrmUpdater::CheckRedirectConfigFile()
     nRet = GetRedirectFromFile(m_DownloadFile.fileName(), conf);
     if(nRet) {
         if(nRet < 0) {
-            QString szError = tr("Failed:") + tr("%2 process the file: %1")
+            QString szError = tr("Failed:") + " " + tr("%2 processed the file: %1")
                                       .arg(m_DownloadFile.fileName()).arg(nRet);
             ui->lbState->setText(szError);
             qCritical(log) << szError;
@@ -467,7 +467,7 @@ int CFrmUpdater::CheckRedirectConfigFile()
         QString szVersion = it->szVersion;
         if(szVersion.isEmpty())
         {
-            QString szError = tr("Failed:") + tr("Configure file content error:")
+            QString szError = tr("Failed:") + " " + tr("Configure file content error:")
                               + m_DownloadFile.fileName();
             ui->lbState->setText(szError);
             qCritical(log) << szError;
@@ -589,7 +589,7 @@ int CFrmUpdater::CheckUpdateConfigFile()
     CONFIG_INFO info;
     nRet = GetConfigFromFile(m_DownloadFile.fileName(), info);
     if(nRet) {
-        QString szError = tr("Failed:") + tr("%2 process the file: %1")
+        QString szError = tr("Failed:") + " " + tr("%2 process the file: %1")
                                       .arg(m_DownloadFile.fileName()).arg(nRet);
         ui->lbState->setText(szError);
         qCritical(log) << szError;
@@ -609,7 +609,7 @@ int CFrmUpdater::CheckUpdateConfigFile()
     
     if(info.files.isEmpty()) {
         QString szError;
-        szError = tr("Failed:") + tr("There is not files in the configure file ")
+        szError = tr("Failed:") + " " + tr("There is not files in the configure file ")
             + m_DownloadFile.fileName();
         ui->lbState->setText(szError);
         qCritical(log) << szError;
@@ -664,7 +664,7 @@ int CFrmUpdater::CheckUpdateConfigFile()
     ui->lbNewVersion->show();
     ui->lbNewArch->setText(tr("New architecture: %1").arg(file.szArchitecture));
     ui->lbNewArch->show();
-    ui->lbState->setText(tr("There is a new version, is it updated?"));
+    ui->lbState->setText(tr("There is a new version, would you like to update?"));
     if(info.version.bForce)
     {
         qDebug(log) << "Force update";
@@ -893,7 +893,7 @@ void CFrmUpdater::slotDownloadSetupFile()
 {
     qDebug(log) << "CFrmUpdater::slotDownloadSetupFile()";
     ui->pbOK->setText(tr("Hide"));
-    ui->lbState->setText(tr("Download ......"));
+    ui->lbState->setText(tr("Downloading ......"));
     if(IsDownLoad())
         emit sigFinished();
     else
@@ -907,7 +907,7 @@ void CFrmUpdater::slotUpdate()
 {
     m_TrayIcon.setToolTip(windowTitle() + " - "
                           + qApp->applicationDisplayName());
-    ui->lbState->setText(tr("Being install update ......"));
+    ui->lbState->setText(tr("Installing update ......"));
     ui->progressBar->hide();
     ui->progressBar->setRange(0, 100);;
     //qDebug(log) << "CFrmUpdater::slotUpdate()";
@@ -918,7 +918,7 @@ void CFrmUpdater::slotUpdate()
         if(!m_DownloadFile.open(QIODevice::ReadOnly))
         {
             QString szErr;
-            szErr = tr("Failed:") + tr("Don't open download file ")
+            szErr = tr("Failed:") + " " + tr("Downloaded file won't open ")
                 + m_DownloadFile.fileName();
             qCritical(log) << szErr;
             ui->lbState->setText(szErr);
@@ -928,7 +928,7 @@ void CFrmUpdater::slotUpdate()
         if(!md5sum.addData(&m_DownloadFile))
         {
             QString szErr;
-            szErr = tr("Failed:") + tr("Don't open download file ")
+            szErr = tr("Failed:") + " " + tr("Downloaded file won't open ")
                     + m_DownloadFile.fileName();
             qCritical(log) << szErr;
             ui->lbState->setText(szErr);
@@ -937,8 +937,8 @@ void CFrmUpdater::slotUpdate()
         if(md5sum.result().toHex() != m_ConfigFile.szMd5sum)
         {
             QString szFail;
-            szFail = tr("Failed:") + tr("Md5sum is different.")
-                    + "\n" + tr("Download file md5sum: ")
+            szFail = tr("Failed:") + " " + tr("Md5sum is different.")
+                    + "\n" + tr("Downloaded file md5sum: ")
                     + md5sum.result().toHex()
                     + "\n" + tr("md5sum in Update configure file: ")
                     + m_ConfigFile.szMd5sum;
@@ -970,7 +970,7 @@ void CFrmUpdater::slotUpdate()
             QUrl url(szHome);
             if(!QDesktopServices::openUrl(url))
             {
-                QString szErr = tr("Failed:") + tr("Open home page fail");
+                QString szErr = tr("Failed:") + " " + tr("Open home page fail");
                 ui->lbState->setText(szErr);
             }
         }
@@ -1027,14 +1027,14 @@ int CFrmUpdater::Execute(const QString szFile)
                          + QDir::separator() + fi.fileName();
                 bRet = f.copy(szExec);
                 if(bRet) {
-                    QString szMsg(tr("Please exec:") + szExec);
+                    QString szMsg(tr("Please exec: ") + szExec);
                     ui->lbState->setText(szMsg);
                     qInfo(log) << szMsg;
                     QUrl url = QUrl::fromLocalFile(cf.absoluteDir().absolutePath());
                     if(!QDesktopServices::openUrl(url))
                     {
                         QString szErr;
-                        szErr = tr("Failed:") + tr("Open the folder fail:")
+                        szErr = tr("Failed:") + " " + tr("Open folder failed: ")
                                 + cf.absoluteDir().absolutePath();
                         qCritical(log) << szErr;
                     }
@@ -1048,7 +1048,7 @@ int CFrmUpdater::Execute(const QString szFile)
                 if(!QDesktopServices::openUrl(url))
                 {
                     QString szErr;
-                    szErr = tr("Failed:") + tr("Open the folder fail:")
+                    szErr = tr("Failed:") + " " + tr("Open the folder failed: ")
                             + fi.absoluteDir().absolutePath();
                     qCritical(log) << szErr;
                 }
@@ -1073,7 +1073,7 @@ int CFrmUpdater::Execute(const QString szFile)
                 if(!QDesktopServices::openUrl(url))
                 {
                     QString szErr = tr("Failed:")
-                    + tr("Execute install program error.%1")
+                    + tr("Execute install program error: %1")
                          .arg(szFile);
                     ui->lbState->setText(szErr);
                     qCritical(log) << szErr;
@@ -1105,7 +1105,7 @@ int CFrmUpdater::Execute(const QString szFile)
                     "/bin/bash",
                     QStringList() << szInstall))
             {
-                QString szErr = tr("Failed:") + tr("Execute") + "/bin/bash "
+                QString szErr = tr("Failed:") + " " + tr("Execute") + "/bin/bash "
                                 + szInstall + "fail";
                 ui->lbState->setText(szErr);
                 nRet = -1;
@@ -1126,7 +1126,7 @@ int CFrmUpdater::Execute(const QString szFile)
             //            QProcess exe;
             //            if(!exe.startDetached(szProgram))
             //            {
-            //                QString szErr = tr("Failed:") + tr("Execute program error.%1")
+            //                QString szErr = tr("Failed:") + " " + tr("Execute program error.%1")
             //                        .arg(szProgram);
             //                ui->lbState->setText(szErr);
             //                nRet = -1;
@@ -1317,7 +1317,7 @@ void CFrmUpdater::on_pbClose_clicked()
     if(m_StateMachine->isRunning())
     {
         QMessageBox::StandardButton ret = QMessageBox::warning(this, tr("Close"),
-                        tr("Is updating, be sure to close?"), QMessageBox::Yes|QMessageBox::No);
+                        tr("Is updating, are you sure to close?"), QMessageBox::Yes|QMessageBox::No);
         if(QMessageBox::No == ret)
         {
             return;

--- a/Src/FrmUpdater/FrmUpdater.ui
+++ b/Src/FrmUpdater/FrmUpdater.ui
@@ -278,7 +278,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="rbEveryDate">
+         <widget class="QRadioButton" name="rbEveryDay">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -286,7 +286,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Every date</string>
+           <string>Every day</string>
           </property>
          </widget>
         </item>
@@ -353,6 +353,9 @@
        </property>
        <property name="text">
         <string>OK(&amp;O)</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/Src/Log/DlgFilter.cpp
+++ b/Src/Log/DlgFilter.cpp
@@ -39,7 +39,7 @@ void CDlgFilter::on_leInclude_editingFinished()
     if(r.isValid())
         return;
     QString szMsg;
-    szMsg = tr("Filter of include is error: ") + r.errorString();
+    szMsg = tr("Filter of include is wrong: ") + r.errorString();
     qCritical() << szMsg;
     QMessageBox::critical(this, tr("Error"), szMsg);
 }
@@ -50,7 +50,7 @@ void CDlgFilter::on_leExclude_editingFinished()
     if(r.isValid())
         return;
     QString szMsg;
-    szMsg = tr("Filter of exclude is error: ") + r.errorString();
+    szMsg = tr("Filter of exclude is wrong: ") + r.errorString();
     qCritical() << szMsg;
     QMessageBox::critical(this, tr("Error"), szMsg);
 }

--- a/Src/Log/DockDebugLog.cpp
+++ b/Src/Log/DockDebugLog.cpp
@@ -133,7 +133,7 @@ CDockDebugLog::CDockDebugLog(QWidget *parent) :
                          QObject::tr("Open Log file"),
                          [](){RabbitCommon::OpenLogFile();});
         pMenu->addAction(QIcon::fromTheme("folder-open"),
-                         tr("Open log folder"), [](){
+                         tr("Open Log folder"), [](){
            RabbitCommon::OpenLogFolder();
         });
     }

--- a/Src/RabbitCommonTools.cpp
+++ b/Src/RabbitCommonTools.cpp
@@ -198,7 +198,7 @@ QString CTools::Information()
     szInfo += QObject::tr("  - Have GUI") + "\n";
 #endif
 #if defined(HAVE_ABOUT)
-    szInfo += QObject::tr("    - Have about diaglog") + "\n";
+    szInfo += QObject::tr("    - Have About dialog") + "\n";
 #ifdef HAVE_CMARK_GFM
     szInfo += QObject::tr("    - Use cmark-gfm") + "\n";
 #elif HAVE_CMARK
@@ -206,9 +206,9 @@ QString CTools::Information()
 #endif
 #endif
 #if defined(HAVE_UPDATE)
-    szInfo += QObject::tr("    - Have update") + "\n";
+    szInfo += QObject::tr("    - Have Update") + "\n";
 #endif
-    szInfo += QObject::tr("    - The cursom title bar for QWidget") + "\n";
+    szInfo += QObject::tr("    - Custom title bar for QWidget") + "\n";
     szInfo += QObject::tr("    - Dock Folder browser") + "\n";
     szInfo += QObject::tr("    - Recent menu") + "\n";
     szInfo += QObject::tr("    - Style") + "\n";
@@ -220,8 +220,8 @@ QString CTools::Information()
 #if defined(BUILD_QUIWidget)
     szInfo += QObject::tr("  - Have QUIWidget") + "\n";
 #endif
-    szInfo += QObject::tr("  - Applicatoin paths and files: ") + "\n";
-    szInfo += QObject::tr("    - Install root path: ") + RabbitCommon::CDir::Instance()->GetDirApplicationInstallRoot() + "\n";
+    szInfo += QObject::tr("  - Application paths and files: ") + "\n";
+    szInfo += QObject::tr("    - Installation root path: ") + RabbitCommon::CDir::Instance()->GetDirApplicationInstallRoot() + "\n";
     szInfo += QObject::tr("    - Application path: ") + RabbitCommon::CDir::Instance()->GetDirApplication() + "\n";
     szInfo += QObject::tr("    - Configure path: ") + RabbitCommon::CDir::Instance()->GetDirConfig() + "\n";
     szInfo += QObject::tr("    - Configure file: ") + RabbitCommon::CDir::Instance()->GetFileApplicationConfigure() + "\n";
@@ -257,7 +257,7 @@ QString CTools::Information()
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 3))
         szInfo += "    - Qt " + QObject::tr("Build Version: ") + QSslSocket::sslLibraryBuildVersionString() + "\n";
 #endif
-        szInfo += "    - Qt " + QObject::tr("Don't install OPENSSL dynamic library. Please install it") + "\n";
+        szInfo += "    - Qt " + QObject::tr("Doesn't have OPENSSL dynamic library installed. Please install it") + "\n";
     }
 #if HAVE_StackWalker
     szInfo += QObject::tr("  - StackWalker") + "\n";
@@ -864,7 +864,7 @@ QMenu* CTools::GetLogMenu(QWidget *parentMainWindow)
                      [](){RabbitCommon::OpenLogFile();});
     pAction->setStatusTip(QObject::tr("Open Log file"));
     pAction = pMenu->addAction(QIcon::fromTheme("folder-open"),
-                     QObject::tr("Open log folder"),
+                     QObject::tr("Open Log folder"),
                      [](){RabbitCommon::OpenLogFolder();});
     pAction->setStatusTip(QObject::tr("Open Log folder"));
     QMainWindow* pMainWindow = qobject_cast<QMainWindow*>(parentMainWindow);

--- a/Src/RabbitCommonTools.cpp
+++ b/Src/RabbitCommonTools.cpp
@@ -649,7 +649,7 @@ int CTools::InstallStartRun(const QString &szName, const QString &szPath, bool b
     QFile f(appPath);
     if(!f.exists())
     {
-        qCCritical(log) << "The desktop file is not exist." << appPath;
+        qCCritical(log) << "The desktop file doesn't exist." << appPath;
         return -2;
     }
     bool ret = f.link(szLink);

--- a/Src/RabbitCommonTools.cpp
+++ b/Src/RabbitCommonTools.cpp
@@ -383,7 +383,7 @@ void CTools::Init(QString szApplicationName,
         if(file.exists())
             InstallTranslatorFile(szFile);
         else
-            qWarning(logTranslation) << "The file doesn't exists:" << szFile;
+            qWarning(logTranslation) << "The file doesn't exists: " << szFile;
     }
     
 #ifdef HAVE_RABBITCOMMON_GUI
@@ -649,7 +649,7 @@ int CTools::InstallStartRun(const QString &szName, const QString &szPath, bool b
     QFile f(appPath);
     if(!f.exists())
     {
-        qCCritical(log) << "The desktop file doesn't exist." << appPath;
+        qCCritical(log) << "The desktop file doesn't exist: " << appPath;
         return -2;
     }
     bool ret = f.link(szLink);

--- a/Src/RabbitRecentMenu.cpp
+++ b/Src/RabbitRecentMenu.cpp
@@ -177,7 +177,7 @@ void CRecentMenu::updateRecentFileActions()
         if(fi.exists())
             szMsg = tr("Recent open: ") + szFile;
         else
-            szMsg = tr("The file is not exists. ") + szFile;
+            szMsg = tr("The file doesn't exists. ") + szFile;
         recentFileAct->setToolTip(szMsg);
         recentFileAct->setStatusTip(szMsg);
         recentFileAct->setWhatsThis(szMsg);

--- a/Src/RabbitRecentMenu.cpp
+++ b/Src/RabbitRecentMenu.cpp
@@ -177,7 +177,7 @@ void CRecentMenu::updateRecentFileActions()
         if(fi.exists())
             szMsg = tr("Recent open: ") + szFile;
         else
-            szMsg = tr("The file doesn't exists. ") + szFile;
+            szMsg = tr("The file doesn't exists: ") + szFile;
         recentFileAct->setToolTip(szMsg);
         recentFileAct->setStatusTip(szMsg);
         recentFileAct->setWhatsThis(szMsg);

--- a/Src/Resource/Translations/RabbitCommon_ar.ts
+++ b/Src/Resource/Translations/RabbitCommon_ar.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ca.ts
+++ b/Src/Resource/Translations/RabbitCommon_ca.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_cs.ts
+++ b/Src/Resource/Translations/RabbitCommon_cs.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_da.ts
+++ b/Src/Resource/Translations/RabbitCommon_da.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_de.ts
+++ b/Src/Resource/Translations/RabbitCommon_de.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_el.ts
+++ b/Src/Resource/Translations/RabbitCommon_el.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_en.ts
+++ b/Src/Resource/Translations/RabbitCommon_en.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_en_GB.ts
+++ b/Src/Resource/Translations/RabbitCommon_en_GB.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_es.ts
+++ b/Src/Resource/Translations/RabbitCommon_es.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_et.ts
+++ b/Src/Resource/Translations/RabbitCommon_et.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_fi.ts
+++ b/Src/Resource/Translations/RabbitCommon_fi.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_fr.ts
+++ b/Src/Resource/Translations/RabbitCommon_fr.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_gd.ts
+++ b/Src/Resource/Translations/RabbitCommon_gd.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_gl.ts
+++ b/Src/Resource/Translations/RabbitCommon_gl.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_hu.ts
+++ b/Src/Resource/Translations/RabbitCommon_hu.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_it.ts
+++ b/Src/Resource/Translations/RabbitCommon_it.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ja.ts
+++ b/Src/Resource/Translations/RabbitCommon_ja.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ko.ts
+++ b/Src/Resource/Translations/RabbitCommon_ko.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_nb.ts
+++ b/Src/Resource/Translations/RabbitCommon_nb.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ne.ts
+++ b/Src/Resource/Translations/RabbitCommon_ne.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_nl.ts
+++ b/Src/Resource/Translations/RabbitCommon_nl.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_nn.ts
+++ b/Src/Resource/Translations/RabbitCommon_nn.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_oc.ts
+++ b/Src/Resource/Translations/RabbitCommon_oc.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_pl.ts
+++ b/Src/Resource/Translations/RabbitCommon_pl.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_pt_BR.ts
+++ b/Src/Resource/Translations/RabbitCommon_pt_BR.ts
@@ -6,164 +6,164 @@
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="20"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Sobre</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="104"/>
         <source>RabbitCommon</source>
-        <translation type="unfinished"></translation>
+        <translation>RabbitCommon</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="129"/>
         <source>Author:KangLin</source>
-        <translation type="unfinished"></translation>
+        <translation>Autor: KangLin</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="185"/>
         <source> Copyright (C) 2018 KangLin Studio</source>
-        <translation type="unfinished"></translation>
+        <translation> Copyright (C) 2018 KangLin Studio</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
-        <translation type="unfinished"></translation>
+        <source>OK(&amp;O)</source>
+        <translation>OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
+        <translation>Detalhes(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão: 1.0.0.0</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
+        <translation>Informações</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
-        <translation type="unfinished"></translation>
+        <translation>Home page: https://github.com/KangLin/Tasks.git</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
-        <translation type="unfinished"></translation>
+        <translation>Doar</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="63"/>
         <source>KangLin</source>
-        <translation type="unfinished"></translation>
+        <translation>KangLin</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="66"/>
         <source>Kang Lin Studio</source>
-        <translation type="unfinished"></translation>
+        <translation>Kang Lin Studio</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="103"/>
         <source>Change log</source>
-        <translation type="unfinished"></translation>
+        <translation>Change log</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="104"/>
         <source>License</source>
-        <translation type="unfinished"></translation>
+        <translation>Licença</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="105"/>
         <source>Thanks</source>
-        <translation type="unfinished"></translation>
+        <translation>Agradecimentos</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="129"/>
         <source>Author: </source>
-        <translation type="unfinished"></translation>
+        <translation>Autor: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="130"/>
         <source> Email: </source>
-        <translation type="unfinished"></translation>
+        <translation> E-mail: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="134"/>
         <source>Home page: </source>
-        <translation type="unfinished"></translation>
+        <translation>Home page: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="139"/>
         <source>%1 - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="141"/>
         <source>Copyright (C)</source>
-        <translation type="unfinished"></translation>
+        <translation>Copyright (C)</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="223"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvar</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="233"/>
         <source>Save donation picture</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvar imagem de doação</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="235"/>
         <source>Images (*.png *.xpm *.jpg)</source>
-        <translation type="unfinished"></translation>
+        <translation>Imagens (*.png *.xpm *.jpg)</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="272"/>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="279"/>
         <source>Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="272"/>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="286"/>
         <source>Arch: </source>
-        <translation type="unfinished"></translation>
+        <translation>Arquitetura: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="279"/>
         <source> (From revision: </source>
-        <translation type="unfinished"></translation>
+        <translation> (Revisão: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="294"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
+        <translation>Falhou:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="294"/>
         <source>Download file is Failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Download do arquivo falhou.</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="311"/>
         <source>### </source>
-        <translation type="unfinished"></translation>
+        <translation>### </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="313"/>
         <source>Build Date/Time: </source>
-        <translation type="unfinished"></translation>
+        <translation>Data/Hora de Compilação: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="314"/>
         <source>File Path: </source>
-        <translation type="unfinished"></translation>
+        <translation>Caminho do Arquivo: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="315"/>
         <source>Arguments: </source>
-        <translation type="unfinished"></translation>
+        <translation>Argumentos: </translation>
     </message>
 </context>
 <context>
@@ -171,13 +171,13 @@
     <message>
         <location filename="../../Log/DlgEdit.ui" line="14"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>Editar</translation>
     </message>
     <message>
         <location filename="../../Log/DlgEdit.ui" line="39"/>
         <location filename="../../Log/DlgEdit.cpp" line="57"/>
         <source>File:</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivo:</translation>
     </message>
 </context>
 <context>
@@ -185,33 +185,33 @@
     <message>
         <location filename="../../Log/DlgFilter.ui" line="14"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Filtrar</translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.ui" line="36"/>
         <source>Include the following(Regular expressions are supported):</source>
-        <translation type="unfinished"></translation>
+        <translation>Incluir o seguinte (há suporte para expressões regulares):</translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.ui" line="46"/>
         <source>Exclude the following(Regular expressions are supported):</source>
-        <translation type="unfinished"></translation>
+        <translation>Excluir o seguinte (há suporte para expressões regulares):</translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
-        <translation type="unfinished"></translation>
+        <source>Filter of include is wrong: </source>
+        <translation>O filtro de inclusão está errado: </translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="44"/>
         <location filename="../../Log/DlgFilter.cpp" line="55"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro</translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
-        <translation type="unfinished"></translation>
+        <source>Filter of exclude is wrong: </source>
+        <translation>O filtro de exclusão está errado: </translation>
     </message>
 </context>
 <context>
@@ -219,7 +219,7 @@
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="47"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Ferramentas</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="50"/>
@@ -227,40 +227,40 @@
         <location filename="../../Log/DockDebugLog.cpp" line="69"/>
         <location filename="../../Log/DockDebugLog.cpp" line="86"/>
         <source>Wrap</source>
-        <translation type="unfinished"></translation>
+        <translation>Quebrar texto</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="58"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation>Limpar</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="72"/>
         <location filename="../../Log/DockDebugLog.cpp" line="81"/>
         <source>No wrap</source>
-        <translation type="unfinished"></translation>
+        <translation>Sem quebra de texto</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="99"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Filtro</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="115"/>
         <location filename="../../Log/DockDebugLog.cpp" line="118"/>
         <location filename="../../Log/DockDebugLog.cpp" line="119"/>
         <source>Set maximum block count</source>
-        <translation type="unfinished"></translation>
+        <translation>Definir contagem máxima de blocos</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
+        <source>Open Log folder</source>
+        <translation>Abrir pasta de Log</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.ui" line="14"/>
         <source>Log</source>
-        <translation type="unfinished"></translation>
+        <translation>Log</translation>
     </message>
 </context>
 <context>
@@ -269,37 +269,37 @@
         <location filename="../../DockFolderBrowser/DockFolderBrowser.ui" line="14"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="121"/>
         <source>Folder browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de pastas</translation>
     </message>
     <message>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="49"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="52"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation>Filtro</translation>
     </message>
     <message>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="67"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="80"/>
         <source>Don&apos;t show hidden files</source>
-        <translation type="unfinished"></translation>
+        <translation>Não exibir arquivos ocultos</translation>
     </message>
     <message>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="69"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="77"/>
         <source>Show hidden files</source>
-        <translation type="unfinished"></translation>
+        <translation>Exibir arquivos ocultos</translation>
     </message>
     <message>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="88"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="104"/>
         <source>Show brief</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar resumo</translation>
     </message>
     <message>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="93"/>
         <location filename="../../DockFolderBrowser/DockFolderBrowser.cpp" line="109"/>
         <source>Show details</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar detalhes</translation>
     </message>
 </context>
 <context>
@@ -307,53 +307,54 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="49"/>
         <source>File browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegador de arquivos</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="156"/>
         <source>Up folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasta acima</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir com o Programa Associado ao Sistema</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="227"/>
         <source>Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation>Horizontal</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="480"/>
         <source>Filetype </source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo de arquivo </translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
+        <translation>Arquivos ocultos</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="464"/>
         <source>File size is too big.
 You can read files up to %1 MB.</source>
-        <translation type="unfinished"></translation>
+        <translation>O tamanho do arquivo é muito grande.
+Você pode ler arquivos de até %1 MB.</translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="473"/>
         <source>Error opening the File!</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro ao abrir o Arquivo!</translation>
     </message>
 </context>
 <context>
@@ -361,63 +362,59 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="14"/>
         <source>Set style</source>
-        <translation type="unfinished"></translation>
+        <translation>Definir estilo</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="24"/>
         <source>Style</source>
-        <translation type="unfinished"></translation>
+        <translation>Estilo</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="32"/>
         <source>Style name:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome do estilo:</translation>
+    </message>
+    <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation>Você precisa reiniciar o programa depois que a caixa de seleção do tema do ícone for alterada.</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
-        <translation type="unfinished"></translation>
+        <translation>Redefinir(&amp;P)</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="42"/>
         <source>Browse(&amp;B)</source>
-        <translation type="unfinished"></translation>
+        <translation>Procurar(&amp;P)</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tema de Ícones:</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="84"/>
         <location filename="../../Style/FrmStyle.ui" line="92"/>
         <source>Fallback theme:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tema de Fallback:</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="111"/>
         <source>You need to restart the program after the fallback theme is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Você precisa reiniciar o programa depois que o Tema de Fallback for alterado.</translation>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
-        <translation type="unfinished"></translation>
+        <translation>OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelar(&amp;C)</translation>
     </message>
 </context>
 <context>
@@ -425,111 +422,91 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="14"/>
         <source>Updater</source>
-        <translation type="unfinished"></translation>
+        <translation>Atualizador</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="72"/>
         <source>Title</source>
-        <translation type="unfinished"></translation>
+        <translation>Título</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="117"/>
         <source>New version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova versão:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="133"/>
         <source>New architecture:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova arquitetura:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="153"/>
         <source>Current version：</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão atual:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="169"/>
         <source>Current architecture：</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquitetura atual:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="196"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="421"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="603"/>
         <source>There is laster version</source>
-        <translation type="unfinished"></translation>
+        <translation>Existe uma versão mais recente</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="229"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Verificar por atualizações</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="243"/>
         <source>Every week</source>
-        <translation type="unfinished"></translation>
+        <translation>Semanal</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="256"/>
         <source>Every Month</source>
-        <translation type="unfinished"></translation>
+        <translation>Mensal</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="273"/>
         <source>Every time</source>
-        <translation type="unfinished"></translation>
+        <translation>Sempre</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
-        <translation type="unfinished"></translation>
+        <source>Every day</source>
+        <translation>Diária</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="301"/>
         <source>Do not prompt again</source>
-        <translation type="unfinished"></translation>
+        <translation>Não avisar novamente</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="311"/>
         <source>Show home page</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar home page</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="355"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="230"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="677"/>
         <source>OK(&amp;O)</source>
-        <translation type="unfinished"></translation>
+        <translation>OK(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
-        <translation type="unfinished"></translation>
+        <translation>Fechar(&amp;F)</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="271"/>
         <source>Current version: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão atual: %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
@@ -542,273 +519,303 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Falhou:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="376"/>
         <source>Downloading %1% [%2/%3]</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixando %1% [%2/%3]</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%2 processou o arquivo: %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro de conteúdo do arquivo de configuração:</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation>Arquitetura atual: %1</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation>Baixando o arquivo de configuração</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation>Baixando o arquivo de atualização</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation>Instalando a atualização</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation>Falha no download do arquivo.</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
+        <translation>%2 processou o arquivo: %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="534"/>
         <source>Don&apos;t find the urls in configure file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Não encontrado os URLs no arquivo de configuração:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="536"/>
         <source>Current version:</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão atual:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="537"/>
         <source>version:</source>
-        <translation type="unfinished"></translation>
+        <translation>versão:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="538"/>
         <source>min update version:</source>
-        <translation type="unfinished"></translation>
+        <translation>versão mín. para atualização:</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="612"/>
         <source>There is not files in the configure file </source>
-        <translation type="unfinished"></translation>
+        <translation>Não há arquivos no arquivo de configuração </translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="652"/>
         <source>The system or architecture is not exist in the configure file </source>
-        <translation type="unfinished"></translation>
+        <translation>O sistema ou a arquitetura não existe no arquivo de configuração </translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="663"/>
         <source>New version: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova versão: %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="665"/>
         <source>New architecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
+        <translation>Nova arquitetura: %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha ao abrir arquivo</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="714"/>
         <source>Parse file %1 fail. It isn&apos;t configure file</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha no processamento do arquivo %1. Não é um arquivo de configuração</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="895"/>
         <source>Hide</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
+        <translation>Ocultar</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
-        <translation type="unfinished"></translation>
+        <translation>Md5sum é diferente.</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="943"/>
         <source>md5sum in Update configure file: </source>
-        <translation type="unfinished"></translation>
+        <translation>Md5sum no arquivo de configuração de Atualização: </translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, execute: </translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation>Falha ao abrir a pasta: </translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erro de execução do programa de instalação: %1</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
-        <source>Execute</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
-        <source>The installer has started, Please close the application</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha ao abrir o arquivo %1</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <source>Execute</source>
+        <translation>Executar</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
+        <source>The installer has started, Please close the application</source>
+        <translation>O instalador foi iniciado, feche o aplicativo</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation>Há uma nova versão, gostaria de atualizar?</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation>Baixando ...</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation>Instalando a atualização ...</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation>O arquivo baixado não abre </translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation>Md5sum do arquivo baixado: </translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
-        <translation type="unfinished"></translation>
+        <translation>Falha ao abrir a home page</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation>Falha ao abrir pasta: </translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation>Erro de execução do programa de instalação: %1</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>Executar</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
-        <translation type="unfinished"></translation>
+        <translation>Executar após a instalação</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Fechar</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
+        <translation>Está atualizando, tem certeza de que vai fechar?</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
-        <translation type="unfinished"></translation>
+        <source>Configure file name</source>
+        <translation>Nome do arquivo de configuração</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation>Conteúdo do arquivo de configuração:</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation>: o conteúdo é a versão</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation>: o conteúdo é o arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation>: o conteúdo é a versão e o arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation>Versão do pacote</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation>Informações</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation>Sistema operacional</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation>Arquitetura</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation>Soma de verificação MD5</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation>Arquivo de pacote, é usado para calcular md5sum</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation>Nome do arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
-        <translation type="unfinished"></translation>
+        <translation>URLs de download de pacotes</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
-        <translation type="unfinished"></translation>
+        <translation>URL do projeto</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
-        <translation type="unfinished"></translation>
+        <translation>Versão mín. para atualização</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
-        <translation type="unfinished"></translation>
+        <translation>Flag de atualização forçada</translation>
     </message>
 </context>
 <context>
@@ -816,515 +823,691 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.ui" line="14"/>
         <source>Details</source>
-        <translation type="unfinished"></translation>
+        <translation>Detalhes</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.ui" line="34"/>
         <source>Tab 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Aba 1</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="31"/>
         <source>Application</source>
-        <translation type="unfinished"></translation>
+        <translation>Aplicativo</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="34"/>
         <source>### RabbitCommon</source>
-        <translation type="unfinished"></translation>
+        <translation>### RabbitCommon</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="37"/>
         <source>RabbitCommon</source>
-        <translation type="unfinished"></translation>
+        <translation>RabbitCommon</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="40"/>
         <source>### Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>### Qt</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="41"/>
         <source>Runtime version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão de runtime: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="42"/>
         <source>Compile version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão de compilação: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="43"/>
         <source>Libraries:</source>
-        <translation type="unfinished"></translation>
+        <translation>Bibliotecas:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="45"/>
         <source>Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="48"/>
         <source>Is debug build: </source>
-        <translation type="unfinished"></translation>
+        <translation>É compilação de depuração (debug): </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="50"/>
         <source>Is shared build: </source>
-        <translation type="unfinished"></translation>
+        <translation>É compilação compartilhada (shared): </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="52"/>
         <source>Path: </source>
-        <translation type="unfinished"></translation>
+        <translation>Caminho: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="54"/>
         <source>Locale: </source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="55"/>
         <source>Icon: </source>
-        <translation type="unfinished"></translation>
+        <translation>Ícone: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="56"/>
         <source>Theme: </source>
-        <translation type="unfinished"></translation>
+        <translation>Tema: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="57"/>
         <source>Search paths:</source>
-        <translation type="unfinished"></translation>
+        <translation>Caminhos de pesquisa:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="63"/>
         <source>Fallback theme: </source>
-        <translation type="unfinished"></translation>
+        <translation>Tema de fallback: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="64"/>
         <source>Fallback search paths:</source>
-        <translation type="unfinished"></translation>
+        <translation>Caminhos de pesquisa de fallback:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="70"/>
         <source>Dependency libraries:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dependência de bibliotecas:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="71"/>
         <source>- OpenSSL:</source>
-        <translation type="unfinished"></translation>
+        <translation>- OpenSSL:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="75"/>
         <location filename="../../DlgAbout/Information.cpp" line="82"/>
         <source>Build Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão de Compilação: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="78"/>
         <source>Installed Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão Instalada: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation type="unfinished"></translation>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation>Não tem a biblioteca dinâmica OPENSSL instalada. Por favor, instale-o</translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation>Tipo de produto: </translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation>Versão do produto: </translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
+        <translation>Variáveis de ambiente:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="88"/>
         <location filename="../../DlgAbout/Information.cpp" line="89"/>
         <source>Standard paths:</source>
-        <translation type="unfinished"></translation>
+        <translation>Caminhos padrão:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="110"/>
         <source>Writable Location:</source>
-        <translation type="unfinished"></translation>
+        <translation>Localização gravável:</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="125"/>
         <source>Qt</source>
-        <translation type="unfinished"></translation>
+        <translation>Qt</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="129"/>
         <source>OS</source>
-        <translation type="unfinished"></translation>
+        <translation>OS</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
-        <translation type="unfinished"></translation>
+        <translation>OS: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="133"/>
         <source>Kernel type: </source>
-        <translation type="unfinished"></translation>
+        <translation>Tipo de kernel: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="134"/>
         <source>Kernel version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão do kernel: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="137"/>
         <source>Boot Id: </source>
-        <translation type="unfinished"></translation>
+        <translation>Boot ID: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="139"/>
         <source>Build ABI: </source>
-        <translation type="unfinished"></translation>
+        <translation>Build ABI: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="140"/>
         <source>CPU: </source>
-        <translation type="unfinished"></translation>
+        <translation>CPU: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="141"/>
         <source>Architecture: </source>
-        <translation type="unfinished"></translation>
+        <translation>Arquitetura: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="143"/>
         <source>Build architecture: </source>
-        <translation type="unfinished"></translation>
+        <translation>Arquitetura de compilação: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="147"/>
         <location filename="../../DlgAbout/Information.cpp" line="162"/>
         <source>Host</source>
-        <translation type="unfinished"></translation>
+        <translation>Host</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="149"/>
         <source>Host name: </source>
-        <translation type="unfinished"></translation>
+        <translation>Nome do host: </translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="151"/>
         <source>Domain name: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome de domínio: </translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
-        <translation type="unfinished"></translation>
+        <translation>Versão: </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
-        <translation type="unfinished"></translation>
+        <translation> (Revisão: </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
-        <translation type="unfinished"></translation>
+        <translation>- Funções:</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
+        <translation>  - Tem GUI</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
-        <translation type="unfinished"></translation>
+        <source>    - Have About dialog</source>
+        <translation>    - Tem a caixa de diálogo Sobre</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
-        <translation type="unfinished"></translation>
+        <source>    - Use cmark-gfm</source>
+        <translation>    - Usa cmark-gfm</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
-        <translation type="unfinished"></translation>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
+        <translation>      - Usa cmark</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Dock Folder browser</source>
+        <translation>    - Navegador de Pasta Dock</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Recent menu</source>
+        <translation>    - Menu recente</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Style</source>
+        <translation>    -Estilo</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
-        <translation type="unfinished"></translation>
+        <source>  - Log</source>
+        <translation>  -Log</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Core dump</source>
+        <translation>    - Despejo de memória</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
-        <translation type="unfinished"></translation>
+        <source>  - Have encrypt(OPENSSL)</source>
+        <translation>  - Tem criptografia (OPENSSL)</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
-        <translation type="unfinished"></translation>
+        <source>  - Have QUIWidget</source>
+        <translation>  - Tem QUIWidget</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
-        <translation type="unfinished"></translation>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation>    - Tem Update</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
+        <translation>    - Barra de título personalizada para QWidget</translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
-        <translation type="unfinished"></translation>
+        <source>  - Application paths and files: </source>
+        <translation>  - Caminhos e arquivos do aplicativo: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Installation root path: </source>
+        <translation>    - Caminho raiz da instalação: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation>    - Caminho do aplicativo: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation>    - Caminho de configuração: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
+        <translation>    - Arquivo de configuração: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Translations path: </source>
+        <translation>    - Caminho das traduções: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation>    - Caminho do log: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation>    - Caminho de dados: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
+        <translation>    - Caminho dos ícones: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
+        <translation>    - Caminho do banco de dados: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
-        <translation type="unfinished"></translation>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation>    - Arquivo de banco de dados: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
+        <translation>    - Caminho dos plugins: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
-        <translation type="unfinished"></translation>
+        <source>  - User folders and files: </source>
+        <translation>  - Pastas e arquivos do usuário: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
-        <translation type="unfinished"></translation>
+        <source>    - Documents path: </source>
+        <translation>    - Caminho dos documentos: </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
-        <translation type="unfinished"></translation>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation>    - Caminho da imagem: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation>- Bibliotecas dependentes:</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation>  - OpenSSL:</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
+        <translation>Versão de Compilação: </translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation type="unfinished"></translation>
+        <source>Runtime Version: </source>
+        <translation>Versão de Runtime: </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation>Versão Instalada: </translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation>Não tem a biblioteca dinâmica OPENSSL instalada. Por favor, instale-a</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
-        <translation type="unfinished"></translation>
+        <translation>  - StackWalker</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
-        <translation type="unfinished"></translation>
+        <translation>  - cmark-gfm</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
-        <translation type="unfinished"></translation>
+        <translation>  - cmark</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
-        <translation type="unfinished"></translation>
+        <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
-        <source>Log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
         <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <source>Log</source>
+        <translation>Log</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurações</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir arquivo de configuração de Log</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
-        <source>Open Log file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
-        <source>Open Log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
         <location filename="../../RabbitCommonTools.cpp" line="865"/>
+        <source>Open Log file</source>
+        <translation>Abrir arquivo de Log</translation>
+    </message>
+    <message>
         <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
+        <source>Open Log folder</source>
+        <translation>Abrir pasta de Log</translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
-        <translation type="unfinished"></translation>
+        <translation>Dock de Log</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="580"/>
         <source>Log configure file</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivo de configuração de log</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="581"/>
         <source>Log configure file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivo de configuração de log:</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="596"/>
         <source>Save as...</source>
-        <translation type="unfinished"></translation>
+        <translation>Salvar como...</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="628"/>
         <source>Log file</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivo de log</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="628"/>
         <source>Log file:</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivo de log:</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="647"/>
         <source>Log folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Pasta de log</translation>
     </message>
     <message>
         <location filename="../../CoreDump/StackTrace.cpp" line="72"/>
         <source>Open log file</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir arquivo de log</translation>
     </message>
     <message>
         <location filename="../../CoreDump/StackTrace.cpp" line="73"/>
         <source>Open core dump folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir pasta de despejo de memória</translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation>Crítico</translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation>Autorização do Administrador</translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation>Autorização do Administrador</translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation>Erro da Aplicação</translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation>Desculpe, o aplicativo travou!</translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation>Caminho atual: </translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation>Arquivo de despejo: </translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation>Arquivo de log: </translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation>Título</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation>Desative a contagem regressiva em %1 s</translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation>Desative a contagem regressiva em %1 s</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation>Prompt</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation>Pergunta</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1332,20 +1515,20 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../CoreDump/StackTrace.cpp" line="75"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Copiar para a área de transferência</translation>
     </message>
 </context>
 <context>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
-        <translation type="unfinished"></translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation>O arquivo não existe: </translation>
     </message>
     <message>
         <location filename="../../Download.cpp" line="418"/>
         <source>Downloading %1% [%2/%3]</source>
-        <translation type="unfinished"></translation>
+        <translation>Baixando %1% [%2/%3]</translation>
     </message>
 </context>
 <context>
@@ -1353,30 +1536,30 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="178"/>
         <source>Recent open: </source>
-        <translation type="unfinished"></translation>
+        <translation>Abertos recentemente: </translation>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
-        <translation type="unfinished"></translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation>O arquivo não existe: </translation>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="186"/>
         <source>Clear Menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Limpar Menu</translation>
     </message>
 </context>
 <context>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
-        <translation type="unfinished"></translation>
+        <source>Open style</source>
+        <translation>Abrir estilo</translation>
     </message>
     <message>
         <location filename="../../Style/Style.cpp" line="198"/>
         <source>Style files(*.qss *.css);; All files(*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Arquivos de estilo(*.qss *.css);; Todos os arquivos (*.*)</translation>
     </message>
 </context>
 <context>
@@ -1384,22 +1567,22 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../TitleBar.cpp" line="88"/>
         <source>Minimize</source>
-        <translation type="unfinished"></translation>
+        <translation>Minimizar</translation>
     </message>
     <message>
         <location filename="../../TitleBar.cpp" line="96"/>
         <source>Maximize</source>
-        <translation type="unfinished"></translation>
+        <translation>Maximizar</translation>
     </message>
     <message>
         <location filename="../../TitleBar.cpp" line="104"/>
         <source>Floating</source>
-        <translation type="unfinished"></translation>
+        <translation>Flutuante</translation>
     </message>
     <message>
         <location filename="../../TitleBar.cpp" line="113"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation>Fechar</translation>
     </message>
 </context>
 </TS>

--- a/Src/Resource/Translations/RabbitCommon_pt_PT.ts
+++ b/Src/Resource/Translations/RabbitCommon_pt_PT.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ro.ts
+++ b/Src/Resource/Translations/RabbitCommon_ro.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_ru.ts
+++ b/Src/Resource/Translations/RabbitCommon_ru.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_sk.ts
+++ b/Src/Resource/Translations/RabbitCommon_sk.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_sl.ts
+++ b/Src/Resource/Translations/RabbitCommon_sl.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_sv.ts
+++ b/Src/Resource/Translations/RabbitCommon_sv.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_th.ts
+++ b/Src/Resource/Translations/RabbitCommon_th.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_tr.ts
+++ b/Src/Resource/Translations/RabbitCommon_tr.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_uk.ts
+++ b/Src/Resource/Translations/RabbitCommon_uk.ts
@@ -25,31 +25,31 @@
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
+        <source>OK(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
-        <source>Information</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
+        <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -199,7 +199,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
+        <source>Filter of include is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -210,7 +210,7 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
+        <source>Filter of exclude is wrong: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,7 +254,7 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
+        <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -315,16 +315,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation type="unfinished"></translation>
@@ -342,6 +332,16 @@
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -374,6 +374,11 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation type="unfinished"></translation>
@@ -385,10 +390,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation type="unfinished"></translation>
@@ -405,17 +406,12 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -481,7 +477,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
+        <source>Every day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -502,28 +498,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -542,18 +518,14 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -562,7 +534,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation type="unfinished"></translation>
@@ -570,6 +541,36 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="470"/>
         <source>Configure file content error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -613,11 +614,6 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation type="unfinished"></translation>
@@ -633,29 +629,8 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
         <source>Md5sum is different.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -664,149 +639,180 @@ You can read files up to %1 MB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
-        <source>Configure file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
-        <source>Configure file output content:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
-        <source>: content is version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
-        <source>: content is file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
-        <source>: content is version and file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
-        <source>Package version</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
-        <source>Time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
-        <source>Operating system</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
-        <source>Architecture</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
-        <source>MD5 checksum</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
-        <source>Package file, Is used to calculate md5sum</source>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
-        <source>File name</source>
+        <source>Configure file name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <source>Configure file output content:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
+        <source>: content is version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
+        <source>: content is file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
+        <source>: content is version and file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
+        <source>Package version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
+        <source>Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
+        <source>Operating system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
+        <source>Architecture</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
+        <source>MD5 checksum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
+        <source>Package file, Is used to calculate md5sum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
+        <source>File name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation type="unfinished"></translation>
     </message>
@@ -931,7 +937,22 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -958,16 +979,6 @@ You can read files up to %1 MB.</source>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
         <source>OS: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1021,268 +1032,259 @@ You can read files up to %1 MB.</source>
         <source>Domain name: </source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
-        <source>    - Use cmark-gfm</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
-        <source>      - Use cmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
-        <source>    - Dock Folder browser</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../RabbitCommonTools.cpp" line="201"/>
-        <source>    - Recent menu</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
-        <source>    - Style</source>
+        <source>    - Have About dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="203"/>
-        <source>  - Log</source>
+        <source>    - Use cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
-        <source>    - Core dump</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
-        <source>  - Have encrypt(OPENSSL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
-        <source>  - Have QUIWidget</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
+        <source>      - Use cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
+        <source>    - Dock Folder browser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="213"/>
-        <source>    - Application path: </source>
+        <source>    - Recent menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
-        <source>    - Configure path: </source>
+        <source>    - Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
-        <source>    - Configure file: </source>
+        <source>  - Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="216"/>
-        <source>    - Translations path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
-        <source>    - Log path: </source>
+        <source>    - Core dump</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
-        <source>    - Data path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
-        <source>    - Icons path: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
-        <source>    - Database path: </source>
+        <source>  - Have encrypt(OPENSSL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
-        <source>    - Database file: </source>
+        <source>  - Have QUIWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
-        <source>    - Plugins path: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="211"/>
+        <source>    - Custom title bar for QWidget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="223"/>
-        <source>  - User folders and files: </source>
+        <source>  - Application paths and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="224"/>
-        <source>    - Documents path: </source>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <source>    - Application path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
+        <source>    - Configure path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
+        <source>    - Configure file: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="228"/>
-        <source>    - Image path: </source>
+        <source>    - Translations path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <source>    - Log path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
+        <source>    - Data path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
+        <source>    - Icons path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="232"/>
-        <source>- Dependent libraries:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
+        <source>    - Database path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="233"/>
-        <source>  - OpenSSL:</source>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
+        <source>    - Database file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
+        <source>    - Plugins path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
-        <source>Build Version: </source>
+        <source>  - User folders and files: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="236"/>
-        <source>Runtime Version: </source>
+        <source>    - Documents path: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
-        <source>Installed Version: </source>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
+        <source>    - Image path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
+        <source>- Dependent libraries:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
+        <source>  - OpenSSL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
+        <source>Build Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
+        <source>Runtime Version: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
+        <source>Installed Version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,6 +1328,186 @@ You can read files up to %1 MB.</source>
         <source>Open core dump folder</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter Password</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
+        <source>AdminAuthorization</source>
+        <comment>Enter your root password to run the program:</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
+        <source>Application Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
+        <source>Current path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
+        <source>Dump file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
+        <source>Log file: </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIInputBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIMessageBox</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
+        <source>Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
+        <source>Query</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RabbitCommon::CCallTrace</name>
@@ -1339,7 +1521,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1357,7 +1539,7 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
+        <source>The file doesn&apos;t exists: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1370,7 +1552,7 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
+        <source>Open style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/Src/Resource/Translations/RabbitCommon_zh_CN.ts
+++ b/Src/Resource/Translations/RabbitCommon_zh_CN.ts
@@ -14,27 +14,32 @@
         <translation>作者： 康林</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
-        <translation>详细</translation>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
+        <source>OK(&amp;O)</source>
+        <translation type="unfinished">确定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation>捐赠</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation>主页： https://github.com/KangLin/Tasks.git</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
         <source>Information</source>
-        <translation>信息</translation>
+        <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation>版本： 1.0.0.0</translation>
     </message>
@@ -47,11 +52,6 @@
         <location filename="../../DlgAbout/DlgAbout.ui" line="185"/>
         <source> Copyright (C) 2018 KangLin Studio</source>
         <translation>版权(C) 2018 康林工作室</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
-        <translation>确定</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="63"/>
@@ -199,8 +199,8 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
-        <translation>过滤器包含表达式错误：</translation>
+        <source>Filter of include is wrong: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="44"/>
@@ -210,8 +210,8 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
-        <translation>过滤器排除表达式错误：</translation>
+        <source>Filter of exclude is wrong: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -254,8 +254,8 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
-        <translation>打开日志文件夹</translation>
+        <source>Open Log folder</source>
+        <translation type="unfinished">打开日志文件夹</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.ui" line="14"/>
@@ -310,20 +310,6 @@
         <translation>文件浏览器</translation>
     </message>
     <message>
-        <source>Update</source>
-        <translation type="vanished">更新</translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation>选项</translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation>隐藏文件</translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation>用系统关联程序打开</translation>
@@ -339,18 +325,6 @@
         <translation>文件类型</translation>
     </message>
     <message>
-        <source>New folder</source>
-        <translation type="vanished">新建文件夹</translation>
-    </message>
-    <message>
-        <source>NewFolder</source>
-        <translation type="vanished">新文件夹</translation>
-    </message>
-    <message>
-        <source>Delete folder</source>
-        <translation type="vanished">删除文件夹</translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
         <translation>关闭</translation>
@@ -359,6 +333,16 @@
         <location filename="../../FileBrowser/FileBrowser.cpp" line="156"/>
         <source>Up folder</source>
         <translation>向上目录</translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="464"/>
@@ -371,10 +355,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="473"/>
         <source>Error opening the File!</source>
         <translation>打开文件错误！</translation>
-    </message>
-    <message>
-        <source>Filetype not supported!</source>
-        <translation type="vanished">文件类型不支持</translation>
     </message>
 </context>
 <context>
@@ -395,6 +375,11 @@ You can read files up to %1 MB.</source>
         <translation>样式名：</translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation>默认(&amp;D)</translation>
@@ -406,10 +391,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation>图标主题：</translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation>图标主题：</translation>
@@ -426,17 +407,12 @@ You can read files up to %1 MB.</source>
         <translation>后备主题改变需要重启程序。</translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation>图标主题选择改变后,需要重启程序.</translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation>确认(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation>取消(&amp;C)</translation>
     </message>
@@ -502,8 +478,8 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
-        <translation>每天</translation>
+        <source>Every day</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="301"/>
@@ -523,29 +499,9 @@ You can read files up to %1 MB.</source>
         <translation>确定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
         <translation>关闭(&amp;C)</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation>正在下载更新文件</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
-        <translation>正在安装更新</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation>当前架构: %1</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation>开始下载配置文件</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="271"/>
@@ -573,11 +529,6 @@ You can read files up to %1 MB.</source>
         <translation>解析文件[%1]失败。它不是配置文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation>有新的版本，是否更新？</translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation>打开文件失败</translation>
@@ -586,16 +537,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="895"/>
         <source>Hide</source>
         <translation>隐藏</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation>下载 ……</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation>正在安装更新 ……</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
@@ -608,19 +549,15 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
         <translation>失败:</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
-        <translation>下载文件失败。</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="376"/>
@@ -628,7 +565,6 @@ You can read files up to %1 MB.</source>
         <translation>正在下载 %1% [%2/%3]</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation>%2 处理文件失败：%1</translation>
@@ -664,120 +600,142 @@ You can read files up to %1 MB.</source>
         <translation>在配置文件中，操作系统或架构不存在</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation>不能打开下载的文件</translation>
-    </message>
-    <message>
-        <source>Md5sum is different. </source>
-        <translation type="vanished">Md5 校验和不同。</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
-        <translation>下载文件的 MD5 校验和:</translation>
-    </message>
-    <message>
-        <source>md5sum in Update.xml:</source>
-        <translation type="vanished">Update.xml 文件中的 MD5 校验和:</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation>请执行：</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation>打开文件夹失败：</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation>请执行：</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation>执行安装错误：%1</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation>打开文件 %1 失败</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation>执行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation>开始安装，请先关闭本程序</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation>打开主页失败</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation>安装后运行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation>正在更新，是否关闭？</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
         <source>Configure file name</source>
         <translation>配置文件名</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
         <source>Configure file output content:</source>
         <translation>配置文件输出内容：</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
         <source>: content is version</source>
         <translation>：内容是版本</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
         <source>: content is file</source>
         <translation>：内容是文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
         <source>: content is version and file</source>
         <translation>：内容是版本和文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation>设置强制更新标识</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
         <source>Package version</source>
         <translation>包版本</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
@@ -785,57 +743,77 @@ You can read files up to %1 MB.</source>
         <translation>MD5 校验和不同。</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="943"/>
-        <source>md5sum in Update configure file: </source>
-        <translation>配置文件中的　MD5 校验和：</translation>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="943"/>
+        <source>md5sum in Update configure file: </source>
+        <translation>配置文件中的&#x3000;MD5 校验和：</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
         <source>Time</source>
         <translation>时间</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
         <source>Operating system</source>
         <translation>操作系统</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
         <source>Architecture</source>
         <translation>架构</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
         <source>MD5 checksum</source>
         <translation>MD5 校验和</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
         <source>Package file, Is used to calculate md5sum</source>
         <translation>包文件，用于计算 md5 校验和</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation>包下载 URLS</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation>项目主页</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation>最小更新版本</translation>
     </message>
@@ -874,11 +852,6 @@ You can read files up to %1 MB.</source>
         <translation>安装的版本： </translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation>未安装 OPENSSL 动态库，请安装！</translation>
-    </message>
-    <message>
         <location filename="../../DlgAbout/Information.cpp" line="88"/>
         <location filename="../../DlgAbout/Information.cpp" line="89"/>
         <source>Standard paths:</source>
@@ -888,11 +861,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../DlgAbout/Information.cpp" line="110"/>
         <source>Writable Location:</source>
         <translation>可写入位置：</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation>环境变量：</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
@@ -975,19 +943,19 @@ You can read files up to %1 MB.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../DlgAbout/Information.cpp" line="85"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../DlgAbout/Information.cpp" line="125"/>
         <source>Qt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation>操作系统：</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
-        <translation>操作系统版本：</translation>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="133"/>
@@ -1035,6 +1003,16 @@ You can read files up to %1 MB.</source>
         <translation>玉兔公共库</translation>
     </message>
     <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../DlgAbout/Information.cpp" line="141"/>
         <source>Architecture: </source>
         <translation>架构：</translation>
@@ -1059,281 +1037,282 @@ You can read files up to %1 MB.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation>(校订版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation>- 功能：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation>  - 界面</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
+        <location filename="../../RabbitCommonTools.cpp" line="201"/>
+        <source>    - Have About dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="203"/>
         <source>    - Use cmark-gfm</source>
         <translation>    使用&#x3000;cmark-gfm</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation>    - 关于对话框</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
         <source>      - Use cmark</source>
         <translation>      - 使用 cmark</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation>    - 更新</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation>    - 自定窗口标题栏</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
+        <location filename="../../RabbitCommonTools.cpp" line="212"/>
         <source>    - Dock Folder browser</source>
         <translation>    - 文件夹浏览器</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="201"/>
+        <location filename="../../RabbitCommonTools.cpp" line="213"/>
         <source>    - Recent menu</source>
         <translation>    - 最近菜单</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
+        <location filename="../../RabbitCommonTools.cpp" line="214"/>
         <source>    - Style</source>
         <translation>    - 样式</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="203"/>
+        <location filename="../../RabbitCommonTools.cpp" line="215"/>
         <source>  - Log</source>
         <translation>  - 日志</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
+        <location filename="../../RabbitCommonTools.cpp" line="216"/>
         <source>    - Core dump</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
+        <location filename="../../RabbitCommonTools.cpp" line="218"/>
         <source>  - Have encrypt(OPENSSL)</source>
         <translation>  - 加密 (OPENSSL)</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <location filename="../../RabbitCommonTools.cpp" line="221"/>
         <source>  - Have QUIWidget</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
-        <translation>  - 应用程序目录和文件：</translation>
+        <source>    - Custom title bar for QWidget</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
-        <translation>    - 安装根目录：</translation>
+        <location filename="../../RabbitCommonTools.cpp" line="223"/>
+        <source>  - Application paths and files: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="213"/>
+        <location filename="../../RabbitCommonTools.cpp" line="224"/>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
         <source>    - Application path: </source>
         <translation>    - 应用程序目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
         <source>    - Configure path: </source>
         <translation>    - 配置目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
         <source>    - Configure file: </source>
         <translation>    - 配置文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="216"/>
+        <location filename="../../RabbitCommonTools.cpp" line="228"/>
         <source>    - Translations path: </source>
         <translation>    - 翻译目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
         <source>    - Log path: </source>
         <translation>    - 日志目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
         <source>    - Data path: </source>
         <translation>    - 数据目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
         <source>    - Icons path: </source>
         <translation>    - 图标目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <location filename="../../RabbitCommonTools.cpp" line="232"/>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
         <source>    - Database path: </source>
         <translation>    - 数据库目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="233"/>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
         <source>    - Database file: </source>
         <translation>    - 数据库文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
         <source>    - Plugins path: </source>
         <translation>    - 插件目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="223"/>
+        <location filename="../../RabbitCommonTools.cpp" line="235"/>
         <source>  - User folders and files: </source>
         <translation>  - 用户目录与文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="224"/>
+        <location filename="../../RabbitCommonTools.cpp" line="236"/>
         <source>    - Documents path: </source>
         <translation>    - 文档目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="228"/>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
         <source>    - Image path: </source>
         <translation>    - 图像目录：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="232"/>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
         <source>- Dependent libraries:</source>
         <translation>- 依赖库：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="233"/>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
         <source>  - OpenSSL:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
         <source>Build Version: </source>
         <translation>编译时版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="236"/>
+        <location filename="../../RabbitCommonTools.cpp" line="248"/>
         <source>Runtime Version: </source>
         <translation>运行时版本：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
         <source>Installed Version: </source>
         <translation>安装的版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation>未安装 OPENSSL 动态库，请安装！</translation>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation>样式</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation>日志</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation>打开日志配置文件</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation>打开日志文件</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation>打开日志文件夹</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation>打开日志文件夹</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation>日志 - 停泊条</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
         <source>Application Error</source>
-        <translation type="vanished">应用错误</translation>
+        <translation>应用错误</translation>
     </message>
     <message>
-        <source>I&apos;m Sorry, Application is Crash!</source>
-        <translation type="vanished">应用崩溃！</translation>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
         <source>Current path: </source>
-        <translation type="vanished">录前目录：</translation>
+        <translation>录前目录：</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
         <source>Dump file: </source>
-        <translation type="vanished">崩溃文件：</translation>
+        <translation>崩溃文件：</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
         <source>Log file: </source>
-        <translation type="vanished">日志文件：</translation>
+        <translation>日志文件：</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="580"/>
@@ -1366,10 +1345,6 @@ You can read files up to %1 MB.</source>
         <translation>日志文件夹</translation>
     </message>
     <message>
-        <source>Folder browser</source>
-        <translation type="vanished">文件夹浏览器</translation>
-    </message>
-    <message>
         <location filename="../../CoreDump/StackTrace.cpp" line="72"/>
         <source>Open log file</source>
         <translation>打开日志文件</translation>
@@ -1380,52 +1355,159 @@ You can read files up to %1 MB.</source>
         <translation>打开内核崩溃文件夹</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
         <source>Critical</source>
-        <translation type="vanished">错误</translation>
+        <translation>错误</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
         <source>AdminAuthorization</source>
         <comment>Enter Password</comment>
-        <translation type="vanished">输入密码</translation>
+        <translation>输入密码</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
         <source>AdminAuthorization</source>
         <comment>Enter your root password to run the program:</comment>
-        <translation type="vanished">输入 root 密码运行程序：</translation>
+        <translation>输入 root 密码运行程序：</translation>
     </message>
 </context>
 <context>
     <name>QUIInputBox</name>
     <message>
-        <source>OK</source>
-        <translation type="vanished">确定</translation>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation>确定</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
         <source>Cancel</source>
-        <translation type="vanished">取消</translation>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QUIMessageBox</name>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
         <source>OK</source>
-        <translation type="vanished">确定</translation>
+        <translation>确定</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
         <source>Cancel</source>
-        <translation type="vanished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
         <source>Prompt</source>
-        <translation type="vanished">提示</translation>
+        <translation>提示</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
         <source>Query</source>
-        <translation type="vanished">查询</translation>
+        <translation>查询</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
         <source>Error</source>
-        <translation type="vanished">错误</translation>
+        <translation>错误</translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1440,8 +1522,8 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
-        <translation>文件不存在：</translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Download.cpp" line="418"/>
@@ -1458,8 +1540,8 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
-        <translation>此文件不存在</translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="186"/>
@@ -1471,8 +1553,8 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
-        <translation>打开样式</translation>
+        <source>Open style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Style/Style.cpp" line="198"/>

--- a/Src/Resource/Translations/RabbitCommon_zh_TW.ts
+++ b/Src/Resource/Translations/RabbitCommon_zh_TW.ts
@@ -14,27 +14,32 @@
         <translation>作者： 康林</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="265"/>
-        <source>Details</source>
-        <translation>詳細</translation>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
+        <source>OK(&amp;O)</source>
+        <translation type="unfinished">確定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="328"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="268"/>
+        <source>Details(&amp;D)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="331"/>
         <source>Donation</source>
         <translation>捐贈</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="293"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="296"/>
         <source>Home page: https://github.com/KangLin/Tasks.git</source>
         <translation>主頁： https://github.com/KangLin/Tasks.git</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="220"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="223"/>
         <source>Information</source>
-        <translation>信息</translation>
+        <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="249"/>
+        <location filename="../../DlgAbout/DlgAbout.ui" line="252"/>
         <source>Version: 1.0.0.0</source>
         <translation>版本： 1.0.0.0</translation>
     </message>
@@ -47,11 +52,6 @@
         <location filename="../../DlgAbout/DlgAbout.ui" line="185"/>
         <source> Copyright (C) 2018 KangLin Studio</source>
         <translation>版權(C) 2018 康林工作室</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/DlgAbout.ui" line="192"/>
-        <source>OK</source>
-        <translation>確定</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/DlgAbout.cpp" line="63"/>
@@ -199,8 +199,8 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="42"/>
-        <source>Filter of include is error: </source>
-        <translation>過濾器包含表達式錯誤：</translation>
+        <source>Filter of include is wrong: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="44"/>
@@ -210,8 +210,8 @@
     </message>
     <message>
         <location filename="../../Log/DlgFilter.cpp" line="53"/>
-        <source>Filter of exclude is error: </source>
-        <translation>過濾器排除表達式錯誤：</translation>
+        <source>Filter of exclude is wrong: </source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -254,8 +254,8 @@
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.cpp" line="136"/>
-        <source>Open log folder</source>
-        <translation>打開日誌文件夾</translation>
+        <source>Open Log folder</source>
+        <translation type="unfinished">打開日誌文件夾</translation>
     </message>
     <message>
         <location filename="../../Log/DockDebugLog.ui" line="14"/>
@@ -310,20 +310,6 @@
         <translation>文件瀏覽器</translation>
     </message>
     <message>
-        <source>Update</source>
-        <translation type="vanished">更新</translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
-        <source>Option</source>
-        <translation>選項</translation>
-    </message>
-    <message>
-        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
-        <source>Hidden file</source>
-        <translation>隱藏文件</translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="212"/>
         <source>Open with the System Associated Program</source>
         <translation>用系統關聯程序打開</translation>
@@ -339,18 +325,6 @@
         <translation>文件類型</translation>
     </message>
     <message>
-        <source>New folder</source>
-        <translation type="vanished">新建文件夾</translation>
-    </message>
-    <message>
-        <source>NewFolder</source>
-        <translation type="vanished">新文件夾</translation>
-    </message>
-    <message>
-        <source>Delete folder</source>
-        <translation type="vanished">刪除文件夾</translation>
-    </message>
-    <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="105"/>
         <source>Close</source>
         <translation>關閉</translation>
@@ -359,6 +333,16 @@
         <location filename="../../FileBrowser/FileBrowser.cpp" line="156"/>
         <source>Up folder</source>
         <translation>向上目錄</translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="180"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FileBrowser/FileBrowser.cpp" line="189"/>
+        <source>Hidden files</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="464"/>
@@ -371,10 +355,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../FileBrowser/FileBrowser.cpp" line="473"/>
         <source>Error opening the File!</source>
         <translation>打開文件錯誤！</translation>
-    </message>
-    <message>
-        <source>Filetype not supported!</source>
-        <translation type="vanished">文件類型不支持</translation>
     </message>
 </context>
 <context>
@@ -395,6 +375,11 @@ You can read files up to %1 MB.</source>
         <translation>樣式名：</translation>
     </message>
     <message>
+        <location filename="../../Style/FrmStyle.ui" line="124"/>
+        <source>You need to restart the program after the icon theme checkbox is changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../Style/FrmStyle.ui" line="165"/>
         <source>Default(&amp;D)</source>
         <translation>默認(&amp;D)</translation>
@@ -406,10 +391,6 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../Style/FrmStyle.ui" line="54"/>
-        <source>Icon theme: </source>
-        <translation>圖標主題：</translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="65"/>
         <source>Icon theme:</source>
         <translation>圖標主題：</translation>
@@ -426,17 +407,12 @@ You can read files up to %1 MB.</source>
         <translation>後備主題改變需要重啟程序。</translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="124"/>
-        <source>You need to restart the programe after the icon theme checked is changed.</source>
-        <translation>圖標主題選擇改變後,需要重啟程序.</translation>
-    </message>
-    <message>
         <location filename="../../Style/FrmStyle.ui" line="172"/>
         <source>Ok(&amp;O)</source>
         <translation>確認(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../Style/FrmStyle.ui" line="179"/>
+        <location filename="../../Style/FrmStyle.ui" line="182"/>
         <source>Cancel(&amp;C)</source>
         <translation>取消(&amp;C)</translation>
     </message>
@@ -502,13 +478,13 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="289"/>
-        <source>Every date</source>
-        <translation>每天</translation>
+        <source>Every day</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="301"/>
         <source>Do not prompt again</source>
-        <translation>不再提示</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.ui" line="311"/>
@@ -523,29 +499,9 @@ You can read files up to %1 MB.</source>
         <translation>確定(&amp;O)</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.ui" line="368"/>
+        <location filename="../../FrmUpdater/FrmUpdater.ui" line="371"/>
         <source>Close(&amp;C)</source>
         <translation>關閉(&amp;C)</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
-        <source>Being download update file</source>
-        <translation>正在下載更新文件</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
-        <source>Being install update</source>
-        <translation>正在安裝更新</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
-        <source>Current archecture: %1</source>
-        <translation>當前架構: %1</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
-        <source>Being Download config file</source>
-        <translation>開始下載配置文件</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="271"/>
@@ -573,11 +529,6 @@ You can read files up to %1 MB.</source>
         <translation>解析文件[%1]失敗。它不是配置文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
-        <source>There is a new version, is it updated?</source>
-        <translation>有新的版本，是否更新？</translation>
-    </message>
-    <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="704"/>
         <source>Open file fail</source>
         <translation>打開文件失敗</translation>
@@ -586,16 +537,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="895"/>
         <source>Hide</source>
         <translation>隱藏</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
-        <source>Download ......</source>
-        <translation>下載 ……</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
-        <source>Being install update ......</source>
-        <translation>正在安裝更新 ……</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
@@ -608,19 +549,15 @@ You can read files up to %1 MB.</source>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1049"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1075"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1092"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1152"/>
         <source>Failed:</source>
         <translation>失敗:</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
-        <source>Download file is Failed.</source>
-        <translation>下載文件失敗。</translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="376"/>
@@ -628,7 +565,6 @@ You can read files up to %1 MB.</source>
         <translation>正在下載 %1% [%2/%3]</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="592"/>
         <source>%2 process the file: %1</source>
         <translation>%2 處理文件失敗：%1</translation>
@@ -664,120 +600,142 @@ You can read files up to %1 MB.</source>
         <translation>在配置文件中，操作系統或架構不存在</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
-        <source>Don&apos;t open download file </source>
-        <translation>不能打開下載的文件</translation>
-    </message>
-    <message>
-        <source>Md5sum is different. </source>
-        <translation type="vanished">Md5 校驗和不同。</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
-        <source>Download file md5sum: </source>
-        <translation>下載文件的 MD5 校驗和:</translation>
-    </message>
-    <message>
-        <source>md5sum in Update.xml:</source>
-        <translation type="vanished">Update.xml 文件中的 MD5 校驗和:</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="995"/>
-        <source>Please exec:</source>
-        <translation>請執行：</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1002"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1016"/>
-        <source>Open the folder fail:</source>
-        <translation>打開文件夾失敗：</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1009"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1030"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1044"/>
         <source>Please exec: </source>
         <translation>請執行：</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1038"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1153"/>
         <source>Execute install program error.%1</source>
         <translation>執行安裝錯誤：%1</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1050"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1093"/>
         <source>Open file %1 fail</source>
         <translation>打開文件 %1 失敗</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1064"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
         <source>Execute</source>
         <translation>執行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1091"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="962"/>
         <source>The installer has started, Please close the application</source>
         <translation>開始安裝，請先關閉本程序</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1108"/>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1124"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="973"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="989"/>
         <source>Open home page fail</source>
         <translation>打開主頁失敗</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1155"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1051"/>
+        <source>Open the folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1196"/>
         <source>Run</source>
         <translation>運行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1156"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1197"/>
         <source>Run after install</source>
         <translation>安裝後運行</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1271"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1319"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1272"/>
-        <source>Is updating, be sure to close?</source>
-        <translation>正在更新，是否關閉？</translation>
-    </message>
-    <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1546"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
         <source>Configure file name</source>
         <translation>配置文件名</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1551"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
         <source>Configure file output content:</source>
         <translation>配置文件輸出內容：</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1552"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1600"/>
         <source>: content is version</source>
         <translation>：內容是版本</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1553"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1601"/>
         <source>: content is file</source>
         <translation>：內容是文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1554"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1602"/>
         <source>: content is version and file</source>
         <translation>：內容是版本和文件</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1615"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1663"/>
         <source>Set force flag</source>
         <translation>設置強製更新標識</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1559"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1607"/>
         <source>Package version</source>
         <translation>包版本</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="82"/>
+        <source>Current architecture: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="221"/>
+        <source>Downloading config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="236"/>
+        <source>Downloading update file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="240"/>
+        <source>Installing update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="316"/>
+        <source>Downloading file has Failed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="455"/>
+        <source>%2 processed the file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="667"/>
+        <source>There is a new version, would you like to update?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="896"/>
+        <source>Downloading ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="910"/>
+        <source>Installing update ......</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="921"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="931"/>
+        <source>Downloaded file won&apos;t open </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../FrmUpdater/FrmUpdater.cpp" line="940"/>
@@ -785,57 +743,77 @@ You can read files up to %1 MB.</source>
         <translation>MD5 校驗和不同。</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="943"/>
-        <source>md5sum in Update configure file: </source>
-        <translation>配置文件中的　MD5 校驗和：</translation>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="941"/>
+        <source>Downloaded file md5sum: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1564"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="943"/>
+        <source>md5sum in Update configure file: </source>
+        <translation>配置文件中的&#x3000;MD5 校驗和：</translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1037"/>
+        <source>Open folder failed: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1076"/>
+        <source>Execute install program error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1320"/>
+        <source>Is updating, are you sure to close?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1612"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1569"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1617"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1575"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1623"/>
         <source>Operating system</source>
         <translation>操作系統</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1580"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1628"/>
         <source>Architecture</source>
         <translation>架構</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1585"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1633"/>
         <source>MD5 checksum</source>
         <translation>MD5 校驗和</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1589"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1637"/>
         <source>Package file, Is used to calculate md5sum</source>
         <translation>包文件，用於計算 md5 校驗和</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1594"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1642"/>
         <source>File name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1599"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1647"/>
         <source>Package download urls</source>
         <translation>包下載 URLS</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1605"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1653"/>
         <source>Project home url</source>
         <translation>項目主頁</translation>
     </message>
     <message>
-        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1610"/>
+        <location filename="../../FrmUpdater/FrmUpdater.cpp" line="1658"/>
         <source>Min update version</source>
         <translation>最小更新版本</translation>
     </message>
@@ -874,11 +852,6 @@ You can read files up to %1 MB.</source>
         <translation>安裝的版本： </translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/Information.cpp" line="85"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation>未安裝 OPENSSL 動態庫，請安裝！</translation>
-    </message>
-    <message>
         <location filename="../../DlgAbout/Information.cpp" line="88"/>
         <location filename="../../DlgAbout/Information.cpp" line="89"/>
         <source>Standard paths:</source>
@@ -888,11 +861,6 @@ You can read files up to %1 MB.</source>
         <location filename="../../DlgAbout/Information.cpp" line="110"/>
         <source>Writable Location:</source>
         <translation>可寫入位置：</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="155"/>
-        <source>Environment:</source>
-        <translation>環境變量：</translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="130"/>
@@ -975,19 +943,19 @@ You can read files up to %1 MB.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../DlgAbout/Information.cpp" line="85"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../DlgAbout/Information.cpp" line="125"/>
         <source>Qt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../DlgAbout/Information.cpp" line="131"/>
-        <source>product type: </source>
-        <translation>操作系統：</translation>
-    </message>
-    <message>
-        <location filename="../../DlgAbout/Information.cpp" line="132"/>
-        <source>product version: </source>
-        <translation>操作系統版本：</translation>
+        <location filename="../../DlgAbout/Information.cpp" line="155"/>
+        <source>Environment Variables:</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../DlgAbout/Information.cpp" line="133"/>
@@ -1035,6 +1003,16 @@ You can read files up to %1 MB.</source>
         <translation>玉兔公共庫</translation>
     </message>
     <message>
+        <location filename="../../DlgAbout/Information.cpp" line="131"/>
+        <source>Product type: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgAbout/Information.cpp" line="132"/>
+        <source>Product version: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../DlgAbout/Information.cpp" line="141"/>
         <source>Architecture: </source>
         <translation>架構：</translation>
@@ -1059,281 +1037,282 @@ You can read files up to %1 MB.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="168"/>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="180"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source>Version: </source>
         <translation>版本：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="170"/>
+        <location filename="../../RabbitCommonTools.cpp" line="182"/>
         <source> (From revision: </source>
         <translation>(校訂版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="184"/>
+        <location filename="../../RabbitCommonTools.cpp" line="196"/>
         <source>- Functions:</source>
         <translation>- 功能：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="186"/>
+        <location filename="../../RabbitCommonTools.cpp" line="198"/>
         <source>  - Have GUI</source>
         <translation>  - 界面</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="191"/>
+        <location filename="../../RabbitCommonTools.cpp" line="201"/>
+        <source>    - Have About dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="203"/>
         <source>    - Use cmark-gfm</source>
         <translation>    使用&#x3000;cmark-gfm</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="189"/>
-        <source>    - Have about diaglog</source>
-        <translation>    - 關於對話框</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="193"/>
+        <location filename="../../RabbitCommonTools.cpp" line="205"/>
         <source>      - Use cmark</source>
         <translation>      - 使用 cmark</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="197"/>
-        <source>    - Have update</source>
-        <translation>    - 更新</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="199"/>
-        <source>    - The cursom title bar for QWidget</source>
-        <translation>    - 自定窗口標題欄</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="200"/>
+        <location filename="../../RabbitCommonTools.cpp" line="212"/>
         <source>    - Dock Folder browser</source>
         <translation>    - 文件夾瀏覽器</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="201"/>
+        <location filename="../../RabbitCommonTools.cpp" line="213"/>
         <source>    - Recent menu</source>
         <translation>    - 最近菜單</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="202"/>
+        <location filename="../../RabbitCommonTools.cpp" line="214"/>
         <source>    - Style</source>
         <translation>    - 樣式</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="203"/>
+        <location filename="../../RabbitCommonTools.cpp" line="215"/>
         <source>  - Log</source>
         <translation>  - 日誌</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="204"/>
+        <location filename="../../RabbitCommonTools.cpp" line="216"/>
         <source>    - Core dump</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="206"/>
+        <location filename="../../RabbitCommonTools.cpp" line="218"/>
         <source>  - Have encrypt(OPENSSL)</source>
         <translation>  - 加密 (OPENSSL)</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <location filename="../../RabbitCommonTools.cpp" line="221"/>
         <source>  - Have QUIWidget</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../../RabbitCommonTools.cpp" line="209"/>
+        <source>    - Have Update</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../RabbitCommonTools.cpp" line="211"/>
-        <source>  - Applicatoin paths and files: </source>
-        <translation>  - 應用程序目錄和文件：</translation>
+        <source>    - Custom title bar for QWidget</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="212"/>
-        <source>    - Install root path: </source>
-        <translation>    - 安裝根目錄：</translation>
+        <location filename="../../RabbitCommonTools.cpp" line="223"/>
+        <source>  - Application paths and files: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="213"/>
+        <location filename="../../RabbitCommonTools.cpp" line="224"/>
+        <source>    - Installation root path: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../RabbitCommonTools.cpp" line="225"/>
         <source>    - Application path: </source>
         <translation>    - 應用程序目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="214"/>
-        <location filename="../../RabbitCommonTools.cpp" line="225"/>
+        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="237"/>
         <source>    - Configure path: </source>
         <translation>    - 配置目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="215"/>
-        <location filename="../../RabbitCommonTools.cpp" line="226"/>
+        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="238"/>
         <source>    - Configure file: </source>
         <translation>    - 配置文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="216"/>
+        <location filename="../../RabbitCommonTools.cpp" line="228"/>
         <source>    - Translations path: </source>
         <translation>    - 翻譯目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="217"/>
+        <location filename="../../RabbitCommonTools.cpp" line="229"/>
         <source>    - Log path: </source>
         <translation>    - 日誌目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="218"/>
-        <location filename="../../RabbitCommonTools.cpp" line="227"/>
+        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="239"/>
         <source>    - Data path: </source>
         <translation>    - 數據目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="219"/>
+        <location filename="../../RabbitCommonTools.cpp" line="231"/>
         <source>    - Icons path: </source>
         <translation>    - 圖標目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="220"/>
-        <location filename="../../RabbitCommonTools.cpp" line="229"/>
+        <location filename="../../RabbitCommonTools.cpp" line="232"/>
+        <location filename="../../RabbitCommonTools.cpp" line="241"/>
         <source>    - Database path: </source>
         <translation>    - 數據庫目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="221"/>
-        <location filename="../../RabbitCommonTools.cpp" line="230"/>
+        <location filename="../../RabbitCommonTools.cpp" line="233"/>
+        <location filename="../../RabbitCommonTools.cpp" line="242"/>
         <source>    - Database file: </source>
         <translation>    - 數據庫文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="222"/>
+        <location filename="../../RabbitCommonTools.cpp" line="234"/>
         <source>    - Plugins path: </source>
         <translation>    - 插件目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="223"/>
+        <location filename="../../RabbitCommonTools.cpp" line="235"/>
         <source>  - User folders and files: </source>
         <translation>  - 用戶目錄與文件：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="224"/>
+        <location filename="../../RabbitCommonTools.cpp" line="236"/>
         <source>    - Documents path: </source>
         <translation>    - 文檔目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="228"/>
+        <location filename="../../RabbitCommonTools.cpp" line="240"/>
         <source>    - Image path: </source>
         <translation>    - 圖像目錄：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="232"/>
+        <location filename="../../RabbitCommonTools.cpp" line="244"/>
         <source>- Dependent libraries:</source>
         <translation>- 依賴庫：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="233"/>
+        <location filename="../../RabbitCommonTools.cpp" line="245"/>
         <source>  - OpenSSL:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="235"/>
-        <location filename="../../RabbitCommonTools.cpp" line="241"/>
-        <location filename="../../RabbitCommonTools.cpp" line="246"/>
+        <location filename="../../RabbitCommonTools.cpp" line="247"/>
+        <location filename="../../RabbitCommonTools.cpp" line="253"/>
+        <location filename="../../RabbitCommonTools.cpp" line="258"/>
         <source>Build Version: </source>
         <translation>編譯時版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="236"/>
+        <location filename="../../RabbitCommonTools.cpp" line="248"/>
         <source>Runtime Version: </source>
         <translation>運行時版本：</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="243"/>
+        <location filename="../../RabbitCommonTools.cpp" line="255"/>
         <source>Installed Version: </source>
         <translation>安裝的版本： </translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="248"/>
-        <source>Don&apos;t install OPENSSL dynamic library. Please install it</source>
-        <translation>未安裝 OPENSSL 動態庫，請安裝！</translation>
+        <location filename="../../RabbitCommonTools.cpp" line="260"/>
+        <source>Doesn&apos;t have OPENSSL dynamic library installed. Please install it</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="251"/>
+        <location filename="../../RabbitCommonTools.cpp" line="263"/>
         <source>  - StackWalker</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="254"/>
+        <location filename="../../RabbitCommonTools.cpp" line="266"/>
         <source>  - cmark-gfm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="256"/>
+        <location filename="../../RabbitCommonTools.cpp" line="268"/>
         <source>  - cmark</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="800"/>
-        <location filename="../../RabbitCommonTools.cpp" line="811"/>
-        <location filename="../../RabbitCommonTools.cpp" line="814"/>
+        <location filename="../../RabbitCommonTools.cpp" line="815"/>
+        <location filename="../../RabbitCommonTools.cpp" line="826"/>
+        <location filename="../../RabbitCommonTools.cpp" line="829"/>
         <source>Style</source>
         <translation>樣式</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="825"/>
-        <location filename="../../RabbitCommonTools.cpp" line="827"/>
+        <location filename="../../RabbitCommonTools.cpp" line="840"/>
+        <location filename="../../RabbitCommonTools.cpp" line="842"/>
         <source>Log</source>
         <translation>日誌</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="830"/>
-        <location filename="../../RabbitCommonTools.cpp" line="842"/>
+        <location filename="../../RabbitCommonTools.cpp" line="845"/>
+        <location filename="../../RabbitCommonTools.cpp" line="857"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="844"/>
-        <location filename="../../RabbitCommonTools.cpp" line="846"/>
         <location filename="../../Log/DockDebugLog.cpp" line="130"/>
+        <location filename="../../RabbitCommonTools.cpp" line="859"/>
+        <location filename="../../RabbitCommonTools.cpp" line="861"/>
         <source>Open Log configure file</source>
         <translation>打開日誌配置文件</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="848"/>
-        <location filename="../../RabbitCommonTools.cpp" line="850"/>
         <location filename="../../Log/DockDebugLog.cpp" line="133"/>
+        <location filename="../../RabbitCommonTools.cpp" line="863"/>
+        <location filename="../../RabbitCommonTools.cpp" line="865"/>
         <source>Open Log file</source>
         <translation>打開日誌文件</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="852"/>
-        <source>Open log folder</source>
-        <translation>打開日誌文件夾</translation>
-    </message>
-    <message>
-        <location filename="../../RabbitCommonTools.cpp" line="854"/>
+        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="869"/>
         <source>Open Log folder</source>
         <translation>打開日誌文件夾</translation>
     </message>
     <message>
-        <location filename="../../RabbitCommonTools.cpp" line="865"/>
-        <location filename="../../RabbitCommonTools.cpp" line="867"/>
+        <location filename="../../RabbitCommonTools.cpp" line="880"/>
+        <location filename="../../RabbitCommonTools.cpp" line="882"/>
         <source>Log dock</source>
         <translation>日誌 - 停泊條</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="200"/>
         <source>Application Error</source>
-        <translation type="vanished">應用錯誤</translation>
+        <translation>應用錯誤</translation>
     </message>
     <message>
-        <source>I&apos;m Sorry, Application is Crash!</source>
-        <translation type="vanished">應用崩潰！</translation>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="202"/>
+        <source>I&apos;m Sorry, Application has Crashed!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="203"/>
         <source>Current path: </source>
-        <translation type="vanished">錄前目錄：</translation>
+        <translation>錄前目錄：</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="205"/>
         <source>Dump file: </source>
-        <translation type="vanished">崩潰文件：</translation>
+        <translation>崩潰文件：</translation>
     </message>
     <message>
+        <location filename="../../CoreDump/QMiniDumper.cpp" line="207"/>
         <source>Log file: </source>
-        <translation type="vanished">日誌文件：</translation>
+        <translation>日誌文件：</translation>
     </message>
     <message>
         <location filename="../../Log/Log.cpp" line="580"/>
@@ -1366,10 +1345,6 @@ You can read files up to %1 MB.</source>
         <translation>日誌文件夾</translation>
     </message>
     <message>
-        <source>Folder browser</source>
-        <translation type="vanished">文件夾瀏覽器</translation>
-    </message>
-    <message>
         <location filename="../../CoreDump/StackTrace.cpp" line="72"/>
         <source>Open log file</source>
         <translation>打開日誌文件</translation>
@@ -1380,52 +1355,159 @@ You can read files up to %1 MB.</source>
         <translation>打開內核崩潰文件夾</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="205"/>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="242"/>
         <source>Critical</source>
-        <translation type="vanished">錯誤</translation>
+        <translation>錯誤</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="213"/>
         <source>AdminAuthorization</source>
         <comment>Enter Password</comment>
-        <translation type="vanished">輸入密碼</translation>
+        <translation>輸入密碼</translation>
     </message>
     <message>
+        <location filename="../../AdminAuthoriser/adminauthorization_x11.cpp" line="215"/>
         <source>AdminAuthorization</source>
         <comment>Enter your root password to run the program:</comment>
-        <translation type="vanished">輸入 root 密碼運行程序：</translation>
+        <translation>輸入 root 密碼運行程序：</translation>
     </message>
 </context>
 <context>
     <name>QUIInputBox</name>
     <message>
-        <source>OK</source>
-        <translation type="vanished">確定</translation>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1152"/>
+        <source>Input box</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1153"/>
+        <source>OK</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1154"/>
         <source>Cancel</source>
-        <translation type="vanished">取消</translation>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="1206"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QUIMessageBox</name>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="877"/>
         <source>OK</source>
-        <translation type="vanished">確定</translation>
+        <translation>確定</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="878"/>
         <source>Cancel</source>
-        <translation type="vanished">取消</translation>
+        <translation>取消</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="930"/>
+        <source>Turn off countdown %1 s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="945"/>
         <source>Prompt</source>
-        <translation type="vanished">提示</translation>
+        <translation>提示</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="948"/>
         <source>Query</source>
-        <translation type="vanished">查詢</translation>
+        <translation>查詢</translation>
     </message>
     <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="952"/>
         <source>Error</source>
-        <translation type="vanished">錯誤</translation>
+        <translation>錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>QUIWidget</name>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="502"/>
+        <source>Silvery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="505"/>
+        <source>Blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="508"/>
+        <source>Light blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="484"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="511"/>
+        <source>Dark blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="514"/>
+        <source>Gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="517"/>
+        <source>Light gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="520"/>
+        <source>Dark gray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="485"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="523"/>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="526"/>
+        <source>Light black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="529"/>
+        <source>Dark black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="486"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="532"/>
+        <source>PS black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="535"/>
+        <source>Flat black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="487"/>
+        <location filename="../../QUIWidget/QUIWidget.cpp" line="538"/>
+        <source>Flat white</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1440,8 +1522,8 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CDownload</name>
     <message>
         <location filename="../../Download.cpp" line="168"/>
-        <source>The file is not exists: </source>
-        <translation>文件不存在：</translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Download.cpp" line="418"/>
@@ -1458,8 +1540,8 @@ You can read files up to %1 MB.</source>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="180"/>
-        <source>The file is not exists. </source>
-        <translation>此文件不存在</translation>
+        <source>The file doesn&apos;t exists: </source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../RabbitRecentMenu.cpp" line="186"/>
@@ -1471,8 +1553,8 @@ You can read files up to %1 MB.</source>
     <name>RabbitCommon::CStyle</name>
     <message>
         <location filename="../../Style/Style.cpp" line="196"/>
-        <source>Open sink</source>
-        <translation>打開樣式</translation>
+        <source>Open style</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../Style/Style.cpp" line="198"/>

--- a/Src/Style/FrmStyle.cpp
+++ b/Src/Style/FrmStyle.cpp
@@ -68,7 +68,7 @@ CFrmStyle::CFrmStyle(QWidget *parent, Qt::WindowFlags f) :
                 qDebug(log) << "Theme:" << themeName;
                 ui->cbIconTheme->addItem(themeName);
             } else {
-                qCritical(log) << "index.theme is not exists:" << fi.fileName()
+                qCritical(log) << "index.theme doesn't exists: " << fi.fileName()
                                << "Theme:" << themeName;
             }
         }

--- a/Src/Style/FrmStyle.ui
+++ b/Src/Style/FrmStyle.ui
@@ -51,7 +51,7 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="gpIconTheme">
      <property name="title">
-      <string>Icon theme: </string>
+      <string>Icon theme:</string>
      </property>
      <property name="checkable">
       <bool>true</bool>
@@ -121,7 +121,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="lbIconThemeChanged">
         <property name="text">
-         <string>You need to restart the programe after the icon theme checked is changed.</string>
+         <string>You need to restart the program after the icon theme checkbox is changed.</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -170,6 +170,9 @@
       <widget class="QPushButton" name="pbOK">
        <property name="text">
         <string>Ok(&amp;O)</string>
+       </property>
+       <property name="default">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/Src/Style/Style.cpp
+++ b/Src/Style/Style.cpp
@@ -193,7 +193,7 @@ QString CStyle::GetStyle()
     }
     qDebug(log) << "Path:" << szPath;
     QWidget* pParent = dynamic_cast<QWidget*>(this->parent());
-    szFile = QFileDialog::getOpenFileName(pParent, tr("Open sink"),
+    szFile = QFileDialog::getOpenFileName(pParent, tr("Open style"),
                                           szPath,
                                           tr("Style files(*.qss *.css);; All files(*.*)"));
     return szFile;

--- a/Test/UnitTests.cpp
+++ b/Test/UnitTests.cpp
@@ -35,7 +35,7 @@ void CUnitTests::testDownloadFileNoExistLocalFile()
     RabbitCommon::CDownload dwonload;
     QObject::connect(&dwonload, &RabbitCommon::CDownload::sigError,
           [&](int nRet, const QString msg){
-        QVERIFY(tr("The file is not exists: ") + szNoExitFile == msg && -6 == nRet);
+        QVERIFY(tr("The file doesn't exists: ") + szNoExitFile == msg && -6 == nRet);
     });
     QObject::connect(&dwonload, &RabbitCommon::CDownload::sigFinished,
                      [&](const QString szPath){


### PR DESCRIPTION
Also fixes some EN typos and has run https://github.com/KangLin/RabbitRemoteControl/pull/71
It seems that Translations weren't being updated for RabbitCommon (as can be seen by the number of translation files updated on this PR). I do believe that CMake only updates translations on RabbitRemoteControl and not RabbitCommon, or maybe it requires building RabbitCommon specifically to have its updates translated by CMake, but my `update_translations.sh` did the trick.